### PR TITLE
ContentView: Remove divider after the property view when the properti…

### DIFF
--- a/iOS/Views/Profile/Body/ProfileView+Skeleton.swift
+++ b/iOS/Views/Profile/Body/ProfileView+Skeleton.swift
@@ -58,8 +58,10 @@ private extension ProfileView.Skeleton {
                 VStack(alignment: .leading, spacing: 5.5) {
                     Summary()
                     Divider()
-                    CorePropertiesView()
-                    Divider()
+                    if let properties = viewModel.content.properties, !properties.isEmpty {
+                        CorePropertiesView()
+                        Divider()
+                    }
                 }
                 .padding(.horizontal)
 


### PR DESCRIPTION
…es are empty

Remove the divider so we don't have duplicated dividers when the properties are empty


<img src="https://github.com/Suwatte/Suwatte/assets/639817/46ec94ba-5fd3-48ec-8166-6ea94f4acc0c" height="50%" width="50%"/><img src="https://github.com/Suwatte/Suwatte/assets/639817/b68f5cb1-a73c-48fc-9f11-17f2d14643a0" height="50%" width="50%"/>
