### PR TITLE
Library: Fix a bug where toggling a library state will result in always failing.

### DIFF
--- a/iOS/Data/Actor/CRUD/Realm+Library.swift
+++ b/iOS/Data/Actor/CRUD/Realm+Library.swift
@@ -85,7 +85,7 @@ extension RealmActor {
     @discardableResult
     func toggleLibraryState(for ids: ContentIdentifier) async -> Bool {
         let source = await DSK.shared.getSource(id: ids.sourceId)
-        if let target = realm.objects(LibraryEntry.self).first(where: { $0.id == ids.id }) {
+        if let target = self.getObject(of: LibraryEntry.self, with: ids.id), !target.isDeleted {
             // Run Removal Event
             Task {
                 do {


### PR DESCRIPTION
…ys failing

When adding a item to the library and then removing it again, and then trying to re-add it again, will result in an endless waiting circle.