### PR TITLE
DirectoryView/SearchView: Added a fallback if totalResultCount is not…

### DIFF
--- a/iOS/Views/Daisuke/DSKDirectoryView/DSK+DV+ViewModel.swift
+++ b/iOS/Views/Daisuke/DSKDirectoryView/DSK+DV+ViewModel.swift
@@ -101,7 +101,7 @@ extension DirectoryView.ViewModel {
         let data: DSKCommon.PagedResult = try await runner.getDirectory(request: request)
 
         await MainActor.run {
-            resultCount = data.totalResultCount
+            resultCount = data.totalResultCount ?? data.results.count
             if data.isLastPage {
                 pagination = .END
             }
@@ -141,6 +141,7 @@ extension DirectoryView.ViewModel {
                 currentEntries.append(contentsOf: data.results)
                 withAnimation {
                     self.result = .loaded(currentEntries)
+                    resultCount = data.totalResultCount ?? currentEntries.count
                     if data.isLastPage {
                         self.pagination = .END
                         return

--- a/iOS/Views/Search/SearchView+CollectionView.swift
+++ b/iOS/Views/Search/SearchView+CollectionView.swift
@@ -85,10 +85,10 @@ extension SearchView.CollectionView {
             VStack(alignment: .leading) {
                 Text(group.sourceName)
                     .font(.headline.weight(.semibold))
-                if let count = result.totalResultCount {
-                    Text(count.description + " Results")
-                        .font(.subheadline.weight(.light))
-                }
+                
+                let count = result.totalResultCount ?? result.results.count
+                Text("\(count.description)\(result.isLastPage ? "" : "+") results")
+                    .font(.subheadline.weight(.light))
             }
             Spacer()
             if !result.isLastPage {


### PR DESCRIPTION
… set in the source, use result count

Right now if the source didn't set the totalResultCount, neither the search nor the DirectoryView will show any result count