### PR TITLE
Fix/misc

### DIFF
--- a/iOS/Data/Actor/CRUD/Realm+ProgressMarker.swift
+++ b/iOS/Data/Actor/CRUD/Realm+ProgressMarker.swift
@@ -212,6 +212,8 @@ extension RealmActor {
             await operation {
                 if markAsRead { // Insert Into Set
                     target.readChapters.insert(objectsIn: nums)
+                    let numberOnlyChapters = nums.map({ ThreadSafeChapter.vnPair(from: $0).1 })
+                    target.readChapters.insert(objectsIn: numberOnlyChapters)
                 } else {
                     nums.forEach {
                         target.readChapters.remove($0)
@@ -229,6 +231,8 @@ extension RealmActor {
         let marker = ProgressMarker()
         marker.id = id.id
         marker.readChapters.insert(objectsIn: nums)
+        let numberOnlyChapters = nums.map({ ThreadSafeChapter.vnPair(from: $0).1 })
+        marker.readChapters.insert(objectsIn: numberOnlyChapters)
         marker.dateRead = nil
 
         await operation {
@@ -287,6 +291,8 @@ extension RealmActor {
         let marker = ProgressMarker()
         marker.id = id.id
         marker.readChapters.insert(objectsIn: chapters)
+        let numberOnlyChapters = chapters.map({ ThreadSafeChapter.vnPair(from: $0).1 })
+        marker.readChapters.insert(objectsIn: numberOnlyChapters)
         marker.dateRead = nil
 
         await operation {

--- a/iOS/Data/Actor/CRUD/Realm+ProgressMarker.swift
+++ b/iOS/Data/Actor/CRUD/Realm+ProgressMarker.swift
@@ -197,6 +197,13 @@ extension RealmActor {
                 await notifySourceOfMarkState(identifier: id, chapters: chapterIds, completed: markAsRead)
             }
         }
+        
+        defer {
+            Task {
+                await updateUnreadCount(for: id)
+            }
+        }
+        
         // Get Object
         let target = getContentMarker(for: id.id)
 
@@ -242,6 +249,12 @@ extension RealmActor {
                     .map(\.chapterId)
 
                 await notifySourceOfMarkState(identifier: id, chapters: chapterIds, completed: markAsRead)
+            }
+        }
+        
+        defer {
+            Task {
+                await updateUnreadCount(for: id)
             }
         }
 

--- a/iOS/Data/Actor/CRUD/Realm+TrackerLink.swift
+++ b/iOS/Data/Actor/CRUD/Realm+TrackerLink.swift
@@ -74,15 +74,19 @@ extension RealmActor {
         for (key, value) in trackerLinkData {
             dict[key] = value
         }
-
+        
         // Add Values from Stored Content
-        let contentTrackerData = linked
-            .appending(content)
-            .flatMap { $0.trackerInfo.asKeyValueSequence() }
+        if Preferences.standard.trackerAutoSync {
+            let contentTrackerData = linked
+                .appending(content)
+                .flatMap { $0.trackerInfo.asKeyValueSequence() }
 
-        for (key, value) in contentTrackerData {
-            dict[key] = value
+            for (key, value) in contentTrackerData {
+                dict[key] = value
+            }
         }
+
+
 
         return dict.filter { !$0.value.isEmpty }
     }

--- a/iOS/Defaults/Keys.swift
+++ b/iOS/Defaults/Keys.swift
@@ -91,7 +91,6 @@ enum STTKeys {
     static let GridItemsPerRow_LS = "APP.grid_items_per_row_landscape"
 
     static let LibrarySections = "LIBRARY.sections_1"
-    static let NonSelectiveSync = "TRACKER.non_selective"
 
     static let SelectiveUpdates = "APP.selective_updates"
     static let JSCommonsVersion = "APP.js_common_version"
@@ -178,4 +177,6 @@ enum STTKeys {
     static let AlwaysMarkFirstPageAsSinglePanel = "READER.mark_first_as_single"
 
     static let UseCompactLibraryView = "APP.compact_library"
+    
+    static let TrackerAutoSync = "APP.tracker_auto_sync"
 }

--- a/iOS/Defaults/Preference.swift
+++ b/iOS/Defaults/Preference.swift
@@ -90,9 +90,6 @@ final class Preferences {
     @UserDefault(STTKeys.NovelFont)
     var novelFont = "AvenirNextCondensed-Regular"
 
-    @UserDefault(STTKeys.NonSelectiveSync)
-    var nonSelectiveSync = false
-
     @UserDefault(STTKeys.SelectiveUpdates)
     var selectiveUpdates = false
 
@@ -188,6 +185,9 @@ final class Preferences {
 
     @UserDefault(STTKeys.AlwaysMarkFirstPageAsSinglePanel)
     var markFirstAsSingle = true
+    
+    @UserDefault(STTKeys.TrackerAutoSync)
+    var trackerAutoSync = true
 }
 
 @propertyWrapper

--- a/iOS/Views/ContentSettings/ContentSettingsView.swift
+++ b/iOS/Views/ContentSettings/ContentSettingsView.swift
@@ -11,6 +11,7 @@ struct ContentSettingsView: View {
     @Preference(\.incognitoMode) var incognitoMode
     @AppStorage(STTKeys.GlobalHideNSFW) var hideNSFW = false
     @Preference(\.blackListProviderOnSourceLevel) var blacklistOnSourceLevel
+    @Preference(\.trackerAutoSync) var trackerAutoSync
 
     var body: some View {
         List {
@@ -40,6 +41,14 @@ struct ContentSettingsView: View {
                 Text("Chapter Providers")
             } footer: {
                 Text("If disabled, hidden providers will only apply to the title being set.")
+            }
+            
+            Section {
+                Toggle("Auto Sync", isOn: $trackerAutoSync)
+            } header: {
+                Text("Trackers")
+            } footer: {
+                Text("If enabled, sources which provide valid tracking ID's will be synced automatically with your installed trackers.")
             }
         }
         .navigationTitle("Content Settings")

--- a/iOS/Views/Daisuke/DSKDirectoryView/DV+FilterView.swift
+++ b/iOS/Views/Daisuke/DSKDirectoryView/DV+FilterView.swift
@@ -201,7 +201,8 @@ extension DirectoryView.FilterView.Cell {
                     $0.title.lowercased().contains(query.lowercased())
                 }
             }
-            return ops.sorted(by: \.title, descending: false)
+            
+            return ops
         }
 
         var body: some View {

--- a/iOS/Views/Profile/Chapter/Sheets/FCS+Options.swift
+++ b/iOS/Views/Profile/Chapter/Sheets/FCS+Options.swift
@@ -55,6 +55,7 @@ struct FCS_Options: View {
             .onChange(of: priorityCache) { value in
                 guard triggeredInitial else { return }
                 STTHelpers.setChapterPriorityMap(for: runnerID, value)
+                didChange()
             }
             .animation(.default, value: providers)
             .animation(.default, value: blacklisted)

--- a/iOS/Views/Profile/ViewModel/CPVM+ActionState.swift
+++ b/iOS/Views/Profile/ViewModel/CPVM+ActionState.swift
@@ -193,7 +193,6 @@ enum ChapterManager {
         guard let chapter else { return nil }
 
         // check below
-
         while counter >= 0 {
             guard let target = chapters.getOrNil(counter as! T.Index), chapter.number == target.number else { break }
             options.append(target)
@@ -204,11 +203,10 @@ enum ChapterManager {
         counter = index
 
         // check above
-
         while counter >= 0 {
             guard let target = chapters.getOrNil(counter as! T.Index), chapter.number == target.number else { break }
             options.append(target)
-            counter -= 1
+            counter += 1
         }
 
         let titleOrder = STTHelpers.getChapterHighPriorityOrder(for: chapter.STTContentIdentifier)

--- a/iOS/Views/Reader/Viewers/ImageViewer/Views/UIKit/Controllers/WebtoonController/WebtoonController.swift
+++ b/iOS/Views/Reader/Viewers/ImageViewer/Views/UIKit/Controllers/WebtoonController/WebtoonController.swift
@@ -205,7 +205,7 @@ extension Controller: ASCollectionDelegate {
         }
 
         let position = resumptionPosition
-        let height = view.frame.height * 0.75
+        let height = view.frame.height * 0.70
         switch item {
         case let .page(page):
             return { [weak self] in


### PR DESCRIPTION
Filters are sorted Source-Side
Marking Chapters as read now updates unread count
Migration copies over read chapters
Fix Action State Chapter Provider Selector
Marking as read now also marks the volume-less order key as read
The vertical loading view height has been reduced.
Auto-Sync can now be disabled.