### PR TITLE
MigrationView: Filter out the same item from the search results

### DIFF
--- a/iOS/Views/Search/SearchView+ViewModel.swift
+++ b/iOS/Views/Search/SearchView+ViewModel.swift
@@ -14,7 +14,7 @@ extension SearchView {
     struct ResultGroup: Hashable {
         let sourceID: String
         let sourceName: String
-        let result: PagedResult
+        var result: PagedResult
     }
 
     struct IncompleteSources: Hashable {
@@ -78,6 +78,32 @@ extension SearchView {
 
             await MainActor.run {
                 state = .loaded("")
+            }
+        }
+
+        func removeContentFromResult(contentIdentifier: ContentIdentifier) {
+            if results.isEmpty {
+                return
+            }
+
+            var resultGroupsToClean: [Int] = []
+
+            for resultGroup in results {
+                if resultGroup.sourceID != contentIdentifier.sourceId {
+                    continue
+                }
+
+                var pagedResult = resultGroup.result
+                var pagedResults = pagedResult.results
+                pagedResults.removeAll { $0.id == contentIdentifier.contentId }
+
+                if pagedResults.isEmpty {
+                    resultGroupsToClean.append(resultGroup.hashValue)
+                }
+            }
+
+            if !resultGroupsToClean.isEmpty {
+                results.removeAll { resultGroupsToClean.contains($0.hashValue) }
             }
         }
 


### PR DESCRIPTION
Filter out the same content id from the Runner Search results because it doesnt make sense to migrate to the same item.