### PR TITLE
ContentLinks enhancements

### DIFF
--- a/Suwatte.xcodeproj/project.pbxproj
+++ b/Suwatte.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		29FB9F232BE43EE800F22E2F /* MigrationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29FB9F222BE43EE800F22E2F /* MigrationHelper.swift */; };
 		DF01DEEA2A587A5D0025700B /* Engine+LibraryUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF01DEE92A587A5D0025700B /* Engine+LibraryUpdate.swift */; };
 		DF01DEEC2A587A680025700B /* Engine+URLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF01DEEB2A587A680025700B /* Engine+URLHandler.swift */; };
 		DF020A442A89A07C00BC5562 /* ArchiveHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF020A432A89A07C00BC5562 /* ArchiveHelper.swift */; };
@@ -496,6 +497,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		29FB9F222BE43EE800F22E2F /* MigrationHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationHelper.swift; sourceTree = "<group>"; };
 		DF01DEE92A587A5D0025700B /* Engine+LibraryUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Engine+LibraryUpdate.swift"; sourceTree = "<group>"; };
 		DF01DEEB2A587A680025700B /* Engine+URLHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Engine+URLHandler.swift"; sourceTree = "<group>"; };
 		DF020A432A89A07C00BC5562 /* ArchiveHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ArchiveHelper.swift; path = Shared/ArchiveHelper/ArchiveHelper.swift; sourceTree = SOURCE_ROOT; };
@@ -971,6 +973,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		29FB9F212BE43ECD00F22E2F /* Migrations */ = {
+			isa = PBXGroup;
+			children = (
+				29FB9F222BE43EE800F22E2F /* MigrationHelper.swift */,
+			);
+			path = Migrations;
+			sourceTree = "<group>";
+		};
 		7660DF769E63B9C1CCADAEB4 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -1696,6 +1706,7 @@
 		DF8D0A092800EE47003E4C3E /* Data */ = {
 			isa = PBXGroup;
 			children = (
+				29FB9F212BE43ECD00F22E2F /* Migrations */,
 				DF27835C2A79A6790098BBA9 /* Extensions */,
 				DFBE48342A25BAB3000ABA16 /* Models */,
 				DF2783322A799BD60098BBA9 /* Actor */,
@@ -2732,6 +2743,7 @@
 				DF1EA4472A70B7FF003E27C7 /* SourceDownloadView.swift in Sources */,
 				DF16F2BC2A5F4F4F00D7AFBB /* DV+ResultsView.swift in Sources */,
 				DF1114882A92F6E300FA8A39 /* WebtoonController+Combine.swift in Sources */,
+				29FB9F232BE43EE800F22E2F /* MigrationHelper.swift in Sources */,
 				DF16F2C12A5F5F0D00D7AFBB /* DV+HistoryView.swift in Sources */,
 				DF52FBC22896F762008FAD3A /* CollectionManagementView.swift in Sources */,
 				DF72E48F281269A900E40E52 /* SauceNao.swift in Sources */,

--- a/iOS/Data/Actor/Observers/Realm+ProfileView.swift
+++ b/iOS/Data/Actor/Observers/Realm+ProfileView.swift
@@ -11,9 +11,10 @@ import RealmSwift
 extension RealmActor {
     typealias Callback<T> = (T) -> Void
     func observeLibraryState(for id: String, _ callback: @escaping Callback<Bool>) async -> NotificationToken {
+        let ids = getLinkedContent(for: id).map(\.id).appending(id)
         let collection = realm
             .objects(LibraryEntry.self)
-            .where { $0.id == id && !$0.isDeleted }
+            .where { $0.id.in(ids) && !$0.isDeleted }
 
         func didUpdate(_ results: Results<LibraryEntry>) {
             let inLibrary = !results.isEmpty
@@ -59,7 +60,7 @@ extension RealmActor {
     }
 
     func observeDownloadStatus(for id: String, _ callback: @escaping Callback<[String: DownloadStatus]>) async -> NotificationToken {
-        let contents = getLinkedContent(for: id, false)
+        let contents = getLinkedContent(for: id)
             .map(\.id)
             .appending(id)
 

--- a/iOS/Data/Migrations/MigrationHelper.swift
+++ b/iOS/Data/Migrations/MigrationHelper.swift
@@ -1,0 +1,43 @@
+//
+//  Migration.swift
+//  Suwatte (iOS)
+//
+//  Created by Seyden on 02.05.24.
+//
+
+import Foundation
+import RealmSwift
+
+class MigrationHelper {
+    static func migrateContentLinks(migration: Migration) {
+        migration.enumerateObjects(ofType: ContentLink.className()) { oldContentLinkObject, newContentLinkObject in
+            guard let oldContentLinkObject = oldContentLinkObject else { return }
+
+            var ids = Set(oldContentLinkObject["ids"] as! RealmSwift.MutableSet<String>)
+
+            migration.enumerateObjects(ofType: LibraryEntry.className()) { _, libraryEntryObject in
+                if let libraryEntryId = libraryEntryObject!["id"] as? String {
+
+                    if ids.remove(libraryEntryId) != nil {
+
+                        ids.forEach { linkContentId in
+                            let newLink = migration.create(ContentLink.className())
+                            newLink["id"] = "\(libraryEntryId)||\(linkContentId)"
+                            newLink["entry"] = libraryEntryObject
+
+                            migration.enumerateObjects(ofType: StoredContent.className()) { _, contentObject in
+                                if let contentId = contentObject!["id"] as? String {
+                                    if contentId == linkContentId {
+                                        newLink["content"] = contentObject
+                                    }
+                                }
+                            }
+                        }
+
+                        migration.delete(newContentLinkObject!)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/iOS/Data/Models/ContentLink.swift
+++ b/iOS/Data/Models/ContentLink.swift
@@ -10,7 +10,22 @@ import IceCream
 import RealmSwift
 
 final class ContentLink: Object, Identifiable, CKRecordConvertible, CKRecordRecoverable {
-    @Persisted(primaryKey: true) var id = UUID().uuidString
-    @Persisted var ids: MutableSet<String>
+    @Persisted(primaryKey: true) var id: String
+    
+    @Persisted var entry : LibraryEntry? {
+        didSet {
+            updateId()
+        }
+    }
+    @Persisted var content: StoredContent?
+    {
+        didSet {
+            updateId()
+        }
+    }
     @Persisted var isDeleted = false
+    
+    fileprivate func updateId() {
+        id = "\(entry?.id ?? "")||\(content?.id ?? "")"
+    }
 }

--- a/iOS/Defaults/Constants.swift
+++ b/iOS/Defaults/Constants.swift
@@ -52,7 +52,7 @@ func getKeyWindow() -> UIWindow? {
         .first { $0.isKeyWindow }
 }
 
-let SCHEMA_VERSION = 15
+let SCHEMA_VERSION = 16
 let STT_BRIDGE_VERSION = "3.0.7"
 
 let STT_USER_AGENT = "Suwatte iOS Client V\(Bundle.main.releaseVersionNumberPretty)"

--- a/iOS/Singletons/AppDelegate.swift
+++ b/iOS/Singletons/AppDelegate.swift
@@ -49,13 +49,20 @@ class STTAppDelegate: NSObject, UIApplicationDelegate {
         }
 
         // Realm
-        var config = Realm.Configuration(schemaVersion: UInt64(SCHEMA_VERSION))
+        var config = Realm.Configuration(schemaVersion: UInt64(SCHEMA_VERSION), migrationBlock: { migration, oldSchemaVersion in
+            if oldSchemaVersion < 16 {
+                MigrationHelper.migrateContentLinks(migration: migration)
+            }
+        })
+
         let directory = FileManager.default.applicationSupport.appendingPathComponent("Database", isDirectory: true)
         if !directory.exists {
             directory.createDirectory()
         }
         config.fileURL = directory.appendingPathComponent("suwatte_db.realm")
         Realm.Configuration.defaultConfiguration = config
+
+        try! Realm.performMigration()
 
         // Analytics
         FirebaseApp.configure()

--- a/iOS/Views/Daisuke/DSKPagesView/Environments/PV+Source.swift
+++ b/iOS/Views/Daisuke/DSKPagesView/Environments/PV+Source.swift
@@ -26,7 +26,7 @@ struct ContentSourcePageView: View {
 
             DSKHighlightTile(data: item,
                              source: source,
-                             inLibrary: model.library.contains(identifier),
+                             inLibrary: model.library.contains(identifier) || model.libraryLinked.contains(identifier),
                              inReadLater: model.readLater.contains(identifier),
                              selection: $selection,
                              hideLibraryBadges: hideLibrayBadges)

--- a/iOS/Views/Profile/Body/Components/ProfileView+BottomBar.swift
+++ b/iOS/Views/Profile/Body/Components/ProfileView+BottomBar.swift
@@ -239,12 +239,14 @@ extension ProfileView.Skeleton.BottomBar {
 
         @ViewBuilder
         var ManageLinkedContentButton: some View {
-            Button {
-                model.presentManageContentLinks = model.identifier
-            } label: {
-                Label("Linked Titles", systemImage: "link")
+            if model.inLibrary {
+                Button {
+                    model.presentManageContentLinks = model.identifier
+                } label: {
+                    Label("Linked Titles", systemImage: "link")
+                }
+                .disabled(!model.source.ablityNotDisabled(\.disableContentLinking))
             }
-            .disabled(!model.source.ablityNotDisabled(\.disableContentLinking))
         }
 
         @ViewBuilder

--- a/iOS/Views/ReadLater/ReadLater+CollectionView.swift
+++ b/iOS/Views/ReadLater/ReadLater+CollectionView.swift
@@ -52,7 +52,7 @@ extension LibraryView.ReadLaterView {
         // Computed
         var highlight: Highlight { data.content!.toHighlight() }
         var sourceId: String { data.content!.sourceId }
-        var inLibrary: Bool { model.library.contains(data.id) }
+        var inLibrary: Bool { model.library.contains(data.id) || model.libraryLinked.contains(data.id) }
 
         // Body
         var body: some View {

--- a/iOS/Views/ReadLater/ReadLater+ContextMenu.swift
+++ b/iOS/Views/ReadLater/ReadLater+ContextMenu.swift
@@ -11,7 +11,7 @@ import UIKit
 
 extension LibraryView.ReadLaterView.CollectionView {
     func inLibrary(_ entry: ReadLater) -> Bool {
-        model.library.contains(entry.id)
+        model.library.contains(entry.id) || model.libraryLinked.contains(entry.id)
     }
 
     func contextMenuProvider(int _: Int, entry: ReadLater) -> UIContextMenuConfiguration? {

--- a/iOS/Views/ReadLater/ReadLater+ViewModel.swift
+++ b/iOS/Views/ReadLater/ReadLater+ViewModel.swift
@@ -31,12 +31,14 @@ extension LibraryView.ReadLaterView {
         }
 
         @Published var library = Set<String>()
+        @Published var libraryLinked = Set<String>()
         @Published var readLater = [ReadLater]()
 
         @Published var initialFetchComplete = false
         @Published var selection: HighlightIdentifier?
 
         private var libraryNotificationToken: NotificationToken?
+        private var libraryLinkedNotificationToken: NotificationToken?
         private var readLaterNotificationToken: NotificationToken?
 
         func obs() {
@@ -67,11 +69,21 @@ extension LibraryView.ReadLaterView {
                     self?.initialFetchComplete = true
                 }
             }
+            
+            libraryLinkedNotificationToken = await actor
+                .observeLinkedIDs { values in
+                    Task { @MainActor [weak self] in
+                        self?.libraryLinked = values
+                    }
+                }
         }
 
         func disconnect() {
             libraryNotificationToken?.invalidate()
             libraryNotificationToken = nil
+            
+            libraryLinkedNotificationToken?.invalidate()
+            libraryLinkedNotificationToken = nil
 
             readLaterNotificationToken?.invalidate()
             readLaterNotificationToken = nil

--- a/iOS/Views/Search/SearchView+CollectionView.swift
+++ b/iOS/Views/Search/SearchView+CollectionView.swift
@@ -135,7 +135,7 @@ extension SearchView.CollectionView {
         }
 
         var inLibrary: Bool {
-            model.library.contains(identifier)
+            model.library.contains(identifier) || model.libraryLinked.contains(identifier)
         }
 
         var inReadLater: Bool {

--- a/iOS/Views/Search/SearchView+ViewModel.swift
+++ b/iOS/Views/Search/SearchView+ViewModel.swift
@@ -35,10 +35,12 @@ extension SearchView {
         @Published var history: [UpdatedSearchHistory] = []
         @Published var incomplete: IncompleteSources = .init(failing: [], noResults: [])
         @Published var library: Set<String> = []
+        @Published var libraryLinked: Set<String> = []
         @Published var savedForLater: Set<String> = []
 
         private let isContentLinkModel: Bool
         private var libraryToken: NotificationToken?
+        private var libraryLinkedToken: NotificationToken?
         private var readLaterToken: NotificationToken?
         private var preSources: [AnyContentSource]?
         init(forLinking: Bool = false, preSources: [AnyContentSource]? = nil) {
@@ -93,7 +95,7 @@ extension SearchView {
                     continue
                 }
 
-                var pagedResult = resultGroup.result
+                let pagedResult = resultGroup.result
                 var pagedResults = pagedResult.results
                 pagedResults.removeAll { $0.id == contentIdentifier.contentId }
 
@@ -137,6 +139,10 @@ extension SearchView {
                 self.library = value
             }
 
+            libraryLinkedToken = await actor.observeLinkedIDs { value in
+                self.libraryLinked = value
+            }
+
             readLaterToken = await actor.observeReadLaterIDs { value in
                 self.savedForLater = value
             }
@@ -145,6 +151,9 @@ extension SearchView {
         func stopObserving() {
             libraryToken?.invalidate()
             libraryToken = nil
+
+            libraryLinkedToken?.invalidate()
+            libraryLinkedToken = nil
 
             readLaterToken?.invalidate()
             readLaterToken = nil


### PR DESCRIPTION
Content Links:

- Remove "Ids" set field from ContentLinks and instead create a ContentLink Object per LibraryEntry -> Content Link
- Add Migration for existing ContentLinks
- Show ContentLinks as "isInLibrary", so titles which are linked will also shown as if they were in the library
- If a ContentLink is clicked on to open the Profile View, instead the Library Entry will be opened

Fixes:
- Show Button "Linked Titles" only when the Title is in the library for ProfileVIew


- [ ] Backup Support will come in an extra PR
