### PR TITLE
ProfileView/Chapters: Decide ActionState Button based on lastRead date and also properly sync tracked items date read to have a correct actionstate

### DIFF
--- a/iOS/Data/Actor/CRUD/Realm+Backup.swift
+++ b/iOS/Data/Actor/CRUD/Realm+Backup.swift
@@ -128,7 +128,7 @@ extension RealmActor {
             guard let reference else { continue }
 
             let marker = ProgressMarker()
-            marker.id = id.id
+            marker.id = reference.id
             marker.chapter = reference
             marker.dateRead = marker.dateRead
             marker.lastPageRead = marker.lastPageRead

--- a/iOS/Data/Models/ProgressMarker.swift
+++ b/iOS/Data/Models/ProgressMarker.swift
@@ -62,7 +62,8 @@ extension ProgressMarker {
               dateRead: dateRead,
               lastPageRead: lastPageRead,
               totalPageCount: totalPageCount,
-              lastPageOffsetPCT: lastPageOffsetPCT
+              lastPageOffsetPCT: lastPageOffsetPCT,
+              chapterOrderKey: chapter?.chapterOrderKey
         )
     }
 }
@@ -73,6 +74,7 @@ struct ThreadSafeProgressMarker : Hashable, Identifiable, Sendable, Encodable {
     let lastPageRead: Int?
     let totalPageCount: Int?
     let lastPageOffsetPCT: Double?
+    let chapterOrderKey: Double?
 
     var isCompleted: Bool {
         guard let lastPageRead, let totalPageCount, totalPageCount >= 1, lastPageRead >= 1 else {

--- a/iOS/Views/Profile/ViewModel/CPVM+Sync.swift
+++ b/iOS/Views/Profile/ViewModel/CPVM+Sync.swift
@@ -63,6 +63,8 @@ extension ViewModel {
         })
 
         let chapters = chapterMap[identifier.id]?.filtered
+        let completedLocalChapters = readChapters[identifier.id]?.filter { $0.value.isCompleted }.map { $0.value.id }
+
         guard let chapters else { return }
         // Source Chapter Sync Handler
         var sourceOriginHighestRead: Double = 0
@@ -113,16 +115,23 @@ extension ViewModel {
 
         let markIndividually = maxReadChapter == sourceOriginHighestRead && !readIDs.isEmpty
 
-        let chaptersToMark = markIndividually ? chapters.filter { readIDs.contains($0.chapterId) }.map(\.chapterOrderKey) : chapters.filter { $0.number <= maxReadChapter }.map(\.chapterOrderKey)
-        await actor.markChaptersByNumber(for: identifier, chapters: Set(chaptersToMark))
+        var chaptersToMark = markIndividually ? chapters.filter { readIDs.contains($0.chapterId) } : chapters.filter { $0.number <= maxReadChapter }
+
+        if completedLocalChapters?.count ?? 0 > 0 {
+            chaptersToMark = chaptersToMark.filter { chapter in !completedLocalChapters!.contains(chapter.id) }
+        }
+
+        chaptersToMark = chaptersToMark.sorted(by: \.index, descending: true)
+
+        await actor.markChapters(for: identifier, chapters: chaptersToMark)
 
         // Notify Linked Titles
         let linked = await actor.getLinkedContent(for: identifier.id)
         await withTaskGroup(of: Void.self, body: { group in
             for link in linked {
-                group.addTask {
+                group.addTask { [chaptersToMark] in
                     await actor
-                        .markChaptersByNumber(for: link.ContentIdentifier, chapters: Set(chaptersToMark))
+                        .markChapters(for: link.ContentIdentifier, chapters: chaptersToMark)
                 }
             }
         })


### PR DESCRIPTION
* Fixed some progress marker bugs which came with the latest PR (this part is important for this fix here)
* Fixed the action state going to the next correct chapter
* Tracked Items now only updates progress markers based on a diff with local data and sets the latest read to Date.now to set the action state to latest chapter