### PR TITLE
Library: Rework Library Views, implemented pinning, fixing multiple bugs

### DIFF
--- a/iOS/Data/Actor/CRUD/Realm+LibraryCollection.swift
+++ b/iOS/Data/Actor/CRUD/Realm+LibraryCollection.swift
@@ -84,4 +84,12 @@ extension RealmActor {
             collection.filter = filter
         }
     }
+
+    func setTitlePinningType(for id: String, pinningType: TitlePinningType) async {
+        let collection = getLibraryCollection(for: id)
+        guard let collection else { return }
+        await operation {
+            collection.pinningType = pinningType
+        }
+    }
 }

--- a/iOS/Data/Extensions/+CollectionFilter.swift
+++ b/iOS/Data/Extensions/+CollectionFilter.swift
@@ -8,6 +8,19 @@
 import Foundation
 import RealmSwift
 
+enum LogicalOperator: Int, PersistableEnum, CaseIterable, Codable {
+    case and, or
+
+    var description: String {
+        switch self {
+            case .and:
+                return "AND"
+            case .or:
+                return "OR"
+        }
+    }
+}
+
 enum ContentSelectionType: Int, PersistableEnum, CaseIterable, Identifiable, Codable {
     case none, only, both
 

--- a/iOS/Data/Models/LibraryCollection.swift
+++ b/iOS/Data/Models/LibraryCollection.swift
@@ -12,7 +12,25 @@ import RealmSwift
 final class LibraryCollection: Object, CKRecordConvertible, CKRecordRecoverable, Identifiable {
     @Persisted(primaryKey: true) var id: String = UUID().uuidString
     @Persisted var name: String
+    @Persisted var pinningType: TitlePinningType?
     @Persisted var order: Int
     @Persisted var filter: LibraryCollectionFilter?
     @Persisted var isDeleted: Bool
+}
+
+enum TitlePinningType: Int, PersistableEnum, CaseIterable, Codable {
+    case none, unread, updated
+
+    var description: String {
+        switch self {
+            case .none:
+                return "None"
+            case .unread:
+                return "Unread"
+            case .updated:
+                return "Updated"
+        }
+    }
+
+    static let pinTypes: [TitlePinningType] = [.unread, .updated]
 }

--- a/iOS/Data/Models/LibraryCollectionFilter.swift
+++ b/iOS/Data/Models/LibraryCollectionFilter.swift
@@ -18,5 +18,7 @@ final class LibraryCollectionFilter: Object, CKRecordConvertible, CKRecordRecove
     @Persisted var sources: List<String>
     @Persisted var tagContains: List<String>
     @Persisted var contentType: List<ExternalContentType>
+    @Persisted var logicalOperator: LogicalOperator = .and
+
     @Persisted var isDeleted: Bool
 }

--- a/iOS/Defaults/Constants.swift
+++ b/iOS/Defaults/Constants.swift
@@ -52,7 +52,7 @@ func getKeyWindow() -> UIWindow? {
         .first { $0.isKeyWindow }
 }
 
-let SCHEMA_VERSION = 17
+let SCHEMA_VERSION = 18
 let STT_BRIDGE_VERSION = "3.0.7"
 
 let STT_USER_AGENT = "Suwatte iOS Client V\(Bundle.main.releaseVersionNumberPretty)"

--- a/iOS/Defaults/Keys.swift
+++ b/iOS/Defaults/Keys.swift
@@ -7,7 +7,8 @@
 
 enum STTKeys {
     static let IntialTabIndex = "APP.initial_tab"
-    static let OpenAllTitlesOnAppear = "LIBRARY.open_all"
+    static let OpenDefaultCollectionEnabled = "LIBRARY.open_default_collection_enabled"
+    static let OpenDefaultCollection = "LIBRARY.open_default_collection"
 
     static let TileStyle = "APP.tile_style"
 
@@ -60,8 +61,11 @@ enum STTKeys {
     static let TimeoutDuration = "LOCAL_AUTH.timeout"
 
     static let ShowOnlyDownloadedTitles = "LIBRARY.download_only"
+    static let FilterByTrackedTitles = "LIBRARY.filter_tracked_titles"
     static let LibraryShowBadges = "LIBRARY.badges"
     static let LibraryBadgeType = "LIBRARY.badge_type"
+    static let LibraryPinningType = "LIBRARY.pinning_type"
+    static let LibraryEnableTitlePinning = "LIBRARY.pinning"
     static let ShowNavigationOverlay = "READER.display_overlay"
 
     // Novel Reader

--- a/iOS/Singletons/StateManager.swift
+++ b/iOS/Singletons/StateManager.swift
@@ -33,6 +33,11 @@ final class StateManager: ObservableObject {
     // Tokens
     private var thumbnailToken: NotificationToken?
     private var collectionToken: NotificationToken?
+    private var collectionInitialized: Bool = false
+
+    func isCollectionInitialized() -> Bool {
+        collectionInitialized
+    }
 
     func initialize() {
         registerNetworkObserver()
@@ -209,6 +214,7 @@ extension StateManager {
             Task { @MainActor in
                 withAnimation { [weak self] in
                     self?.collections = value
+                    self?.collectionInitialized = true
                 }
             }
         }
@@ -220,6 +226,7 @@ extension StateManager {
 
         collectionToken?.invalidate()
         collectionToken = nil
+        collectionInitialized = false
     }
 }
 

--- a/iOS/Singletons/UserDefaultsSync.swift
+++ b/iOS/Singletons/UserDefaultsSync.swift
@@ -12,7 +12,8 @@ class UDSync {
     static func sync() {
         return
         guard isUserLoggedInToiCloud() else { return }
-        var keys: [String] = [STTKeys.OpenAllTitlesOnAppear,
+        var keys: [String] = [STTKeys.OpenDefaultCollectionEnabled,
+                              STTKeys.OpenDefaultCollection,
                               STTKeys.TileStyle,
                               STTKeys.LibraryGridSortKey,
                               STTKeys.LibraryGridSortOrder,

--- a/iOS/Views/Library/CompactView/CompactLibraryView.swift
+++ b/iOS/Views/Library/CompactView/CompactLibraryView.swift
@@ -8,10 +8,20 @@
 import SwiftUI
 
 struct CompactLibraryView: View {
+    @AppStorage(STTKeys.OpenDefaultCollection) var defaultCollectionToOpen = ""
+    @AppStorage(STTKeys.OpenDefaultCollectionEnabled) var openDefaultCollectionOnAppear = false
+
+    @StateObject var appState = StateManager.shared
+
     var body: some View {
         ZStack {
-            LibraryView.LibraryGrid(collection: nil, readingFlag: nil, useLibrary: true)
+            if appState.isCollectionInitialized() {
+                let collectionToOpen: LibraryCollection? = openDefaultCollectionOnAppear ? StateManager.shared.collections.first { $0.id == defaultCollectionToOpen } : nil
+
+                LibraryView.LibraryGrid(collection: collectionToOpen, readingFlag: nil, useLibrary: true)
+            } else {
+                ProgressView()
+            }
         }
-        .navigationTitle("Library")
     }
 }

--- a/iOS/Views/Library/Sheets/ManageCollectionsView.swift
+++ b/iOS/Views/Library/Sheets/ManageCollectionsView.swift
@@ -13,6 +13,8 @@ extension LibraryView {
         @Environment(\.presentationMode) private var presentationMode
         @EnvironmentObject private var model: StateManager
 
+        @State private var editMode = EditMode.inactive
+
         var collections: [LibraryCollection] {
             model.collections
         }
@@ -25,11 +27,10 @@ extension LibraryView {
                 }
                 .navigationTitle("Collections")
                 .navigationBarTitleDisplayMode(.inline)
-                .toolbar(content: {
-                    EditButton()
-                })
+                .toolbar(content: { EditButton() })
                 .closeButton()
                 .animation(.default, value: collections)
+                .environment(\.editMode, $editMode)
             }
         }
     }
@@ -47,7 +48,9 @@ extension MCV {
         Section {
             ForEach(collections) { collection in
                 NavigationLink {
-                    CollectionManagementView(collection: collection, collectionName: collection.name)
+                    Form {
+                        CollectionManagementView(collection: collection, collectionName: collection.name)
+                    }
                 } label: {
                     Text(collection.name)
                 }

--- a/iOS/Views/Library/Views/LibraryGrid/Actors/LibraryGrid+ViewModel.swift
+++ b/iOS/Views/Library/Views/LibraryGrid/Actors/LibraryGrid+ViewModel.swift
@@ -92,7 +92,7 @@ extension LibraryView.LibraryGrid {
                 } else {
                     pinnedLibraryToken?.invalidate()
                     pinnedLibraryToken = nil
-                    pinnedLibrary = nil
+                    pinnedLibrary = []
                 }
             }
         }

--- a/iOS/Views/Library/Views/LibraryGrid/Actors/LibraryGrid+ViewModel.swift
+++ b/iOS/Views/Library/Views/LibraryGrid/Actors/LibraryGrid+ViewModel.swift
@@ -22,16 +22,19 @@ extension LibraryView.LibraryGrid {
             didSet {
                 // Clear Selections when user exits selection mode
                 if !isSelecting {
-                    selectedIndexes.removeAll()
+                    clearSelection()
                 }
             }
         }
 
-        @Published var selectedIndexes: Set<Int> = []
+        @Published var selectedPinnedIndexes: Set<Int> = []
+        @Published var selectedRegularIndexes: Set<Int> = []
         @Published var navSelection: LibraryEntry?
         @Published var query = ""
-        @Published var library: [LibraryEntry]?
-        private var token: NotificationToken?
+        @Published var regularLibrary: [LibraryEntry]?
+        @Published var pinnedLibrary: [LibraryEntry]?
+        private var regularLibraryToken: NotificationToken?
+        private var pinnedLibraryToken: NotificationToken?
         private var didSet = false
 
         func setFilterGroups(collection: LibraryCollection? = nil, readingFlag: LibraryFlag? = nil) {
@@ -43,40 +46,71 @@ extension LibraryView.LibraryGrid {
         }
 
         func disconnect() {
-            token?.invalidate()
-            token = nil
+            regularLibraryToken?.invalidate()
+            regularLibraryToken = nil
+            regularLibrary = nil
+            pinnedLibraryToken?.invalidate()
+            pinnedLibraryToken = nil
+            pinnedLibrary = nil
         }
 
-        func didSetResult(_ lib: [LibraryEntry]) {
-            withAnimation {
-                self.library = lib
-            }
+        func clearSelection() {
+            selectedPinnedIndexes.removeAll()
+            selectedRegularIndexes.removeAll()
         }
 
-        func observe(downloadsOnly: Bool, key: KeyPath, order: SortOrder) {
+        func isLibraryStillLoading() -> Bool {
+            regularLibrary == nil || pinnedLibrary == nil
+        }
+
+        func observe(filterByDownloadedTitles: Bool, filterByTrackedTitles: Bool, key: KeyPath, order: SortOrder, pinningType: TitlePinningType? = nil) {
             disconnect()
             let state: LibraryGridState = .init(collection: collection?.freeze(),
                                                 readingFlag: readingFlag,
                                                 query: query,
                                                 sort: key,
                                                 order: order,
-                                                showOnlyDownloadedTitles: downloadsOnly)
+                                                filterByDownloadedTitles: filterByDownloadedTitles,
+                                                filterByTrackedTitles: filterByTrackedTitles,
+                                                titlePinningType: pinningType)
             Task { @MainActor in
-                token = await RealmActor
-                    .shared()
-                    .observeLibrary(state: state) { [weak self] result in
-                        self?.didSetResult(result)
+                let actor = await RealmActor.shared()
+                regularLibraryToken = await actor
+                    .observeRegularLibrary(state: state) { [weak self] result in
+                        withAnimation {
+                            self?.regularLibrary = result
+                        }
                     }
+
+                if state.getTitlePinningType() != nil {
+                    pinnedLibraryToken = await actor
+                        .observePinnedLibrary(state: state) { [weak self] result in
+                            withAnimation {
+                                self?.pinnedLibrary = result
+                            }
+                        }
+                } else {
+                    pinnedLibraryToken?.invalidate()
+                    pinnedLibraryToken = nil
+                    pinnedLibrary = nil
+                }
             }
         }
 
         func refresh() {
-            guard let library, !library.isEmpty else { return }
+            guard let regularLibrary, let pinnedLibrary else {
+                return
+            }
+
+            if pinnedLibrary.isEmpty && regularLibrary.isEmpty {
+                return
+            }
+
             ToastManager.shared.info("Refreshing Database.")
 
-            Task { [library] in
+            Task { [regularLibrary, pinnedLibrary] in
                 let actor = await Suwatte.RealmActor.shared()
-                for content in library.compactMap(\.content) {
+                for content in (regularLibrary + pinnedLibrary).compactMap(\.content) {
                     await actor.refreshStored(contentId: content.contentId, sourceId: content.sourceId)
                 }
                 ToastManager.shared.info("Database Refreshed")

--- a/iOS/Views/Library/Views/LibraryGrid/Library+CollectionView.swift
+++ b/iOS/Views/Library/Views/LibraryGrid/Library+CollectionView.swift
@@ -17,7 +17,10 @@ extension LibraryView {
         // Defaults
         @AppStorage(STTKeys.LibraryGridSortKey) private var sortKey: KeyPath = .name
         @AppStorage(STTKeys.LibraryGridSortOrder) private var sortOrder: SortOrder = .asc
+        @AppStorage(STTKeys.LibraryPinningType) var pinningType: TitlePinningType = .unread
+        @AppStorage(STTKeys.LibraryEnableTitlePinning) var isTitlePinningEnabled = false
         @AppStorage(STTKeys.ShowOnlyDownloadedTitles) private var showDownloadsOnly = false
+        @AppStorage(STTKeys.FilterByTrackedTitles) private var filterByTrackedTitles = false
         // State
         @State private var presentOptionsSheet = false
         @State private var presentMigrateSheet = false
@@ -36,11 +39,15 @@ extension LibraryView {
         private var readingFlag : LibraryFlag? {
             model.readingFlag
         }
-        
-        private var colleciton: LibraryCollection? {
-            model.collection
+
+        private var regularLibrary: [LibraryEntry] {
+            model.regularLibrary ?? []
         }
-        
+
+        private var pinnedLibrary: [LibraryEntry] {
+            model.pinnedLibrary ?? []
+        }
+
         
         init(collection: LibraryCollection?, readingFlag: LibraryFlag?, useLibrary: Bool = false) {
             let m = ViewModel()
@@ -49,157 +56,233 @@ extension LibraryView {
             self.useLibrary = useLibrary
         }
 
-        private func observe(_: AnyHashable? = nil) {
-            model.observe(downloadsOnly: showDownloadsOnly, key: sortKey, order: sortOrder)
+        private func refreshCollection() {
+            guard let currentCollection = model.collection else {
+                return
+            }
+
+            model.collection = collections?.first { $0.id == currentCollection.id }
         }
 
-        var body: some View {
+        private func observe(_: AnyHashable? = nil) {
+            model.observe(filterByDownloadedTitles: showDownloadsOnly, filterByTrackedTitles: filterByTrackedTitles, key: sortKey, order: sortOrder, pinningType: isTitlePinningEnabled ? pinningType : nil)
+        }
+
+        var content: some View {
             ZStack {
-                if let library = model.library {
-                    if library.isEmpty {
+                if !model.isLibraryStillLoading() {
+                    if regularLibrary.isEmpty && pinnedLibrary.isEmpty {
                         No_ENTRIES
                     } else {
-                        MainView(library)
+                        LibraryGrid.Grid()
+                            .modifier(SelectionModifier(regularEntries: regularLibrary, pinnedEntries: pinnedLibrary))
+                            .environment(\.libraryIsSelecting, model.isSelecting)
+                            .animation(.default, value: regularLibrary)
+                            .animation(.default, value: pinnedLibrary)
                             .onChange(of: sortKey, perform: observe)
                             .onChange(of: sortOrder, perform: observe)
-                            .onChange(of: showDownloadsOnly, perform: observe)
                     }
+
                 } else {
                     ProgressView()
                 }
             }
+            .modifier(CollectionModifier(selection: $model.navSelection))
+            .onChange(of: filterByTrackedTitles, perform: observe)
+            .onChange(of: showDownloadsOnly, perform: observe)
+            .onChange(of: isTitlePinningEnabled, perform: observe)
+            .onChange(of: pinningType, perform: observe)
             .onChange(of: model.readingFlag, perform: observe)
             .onChange(of: model.collection, perform: observe)
-            .task {
-                observe()
-            }
-            .onDisappear {
-                model.disconnect()
-            }
-            .toolbar {
-                ToolbarItemGroup(placement: .navigationBarTrailing) {
-                    if model.isSelecting {
-                        Button("Done") {
-                            model.isSelecting = false
+            .onChange(of: stateManager.collections, perform: observe)
+        }
+
+        var body: some View {
+            content
+                .task {
+                    observe()
+                }
+                .onDisappear {
+                    model.disconnect()
+                }
+                .toolbar {
+                    ToolbarItemGroup(placement: .navigationBarTrailing) {
+                        if model.isSelecting {
+                            Button("Done") {
+                                model.isSelecting = false
+                            }
+                        } else {
+                            NavMenu
                         }
-                    } else {
-                        Menu {
-                            // Select
-                            Button {
-                                model.isSelecting = true
-                            } label: {
-                                Label("Select", systemImage: "checkmark.circle")
+                    }
+                }
+                .navigationBarTitleDisplayMode(.inline)
+                .conditional(useCompactView, transform: { view in
+                    view
+                        .toolbar {
+                            ToolbarItem(placement: .principal) {
+                                CollectionSelectorHeader
                             }
-                            Divider()
+                        }
+                })
+                .navigationBarTitle(NAV_TITLE)
+                .environmentObject(model)
+                .searchable(text: $model.query, placement: .navigationBarDrawer(displayMode: .always), prompt: Text("Search \(NAV_TITLE)"))
+                .onReceive(model.$query.debounce(for: .seconds(0.15), scheduler: DispatchQueue.main).dropFirst()) { _ in
+                    observe()
+                }
+                .sheet(isPresented: $presentOptionsSheet, onDismiss: { refreshCollection() }) {
+                    SmartNavigationView {
+                        OptionsSheet()
+                            .environmentObject(model)
+                    }
+                }
+                .sheet(isPresented: $presentStatsSheet, content: {
+                    SmartNavigationView {
+                        LoadableStatisticsView()
+                    }
+                })
+                .fullScreenCover(isPresented: $presentMigrateSheet, content: {
+                    PreMigrationView()
+                })
+                .sheet(isPresented: $presentCollectionSheet) {
+                    ManageCollectionsView()
+                }
+        }
 
-                            Picker("Sort By", selection: $sortKey) {
-                                ForEach(KeyPath.allCases) { path in
-                                    Button(path.description) {
-                                        self.sortKey = path
-                                    }
-                                    .tag(path)
-                                }
+        @ViewBuilder
+        private var NavMenu: some View {
+            Menu {
+                Section {
+                    ForEach(KeyPath.allCases) { path in
+                        Button {
+                            withAnimation {
+                                self.sortKey = path
                             }
-                            .pickerStyle(.menu)
-
-                            Button {
-                                sortOrder.toggle()
-
-                            } label: {
-                                Label("Order", systemImage: "chevron.\(sortOrder.ascending ? "up" : "down")")
-                            }
-
-                            Divider()
-
-                            Menu("More") {
-                                Button {
-                                    presentOptionsSheet.toggle()
-                                } label: {
-                                    Label("Settings", systemImage: "gearshape")
-                                }
-
-                                Button {
-                                    presentStatsSheet.toggle()
-                                } label: {
-                                    Label("Statistics", systemImage: "chart.bar")
-                                }
-
-                                Button {
-                                    presentMigrateSheet.toggle()
-                                } label: {
-                                    Label("Migrate", systemImage: "shippingbox")
-                                }
-                            }
-
-                            Button {
-                                Task {
-                                    model.refresh()
-                                }
-                            } label: {
-                                Label("Refresh Database", systemImage: "arrow.triangle.2.circlepath")
-                            }
-
-                            // Compact Library Helpers
-                            Divider()
-
-                            if useCompactView {
-                                Button { useCompactView.toggle() } label: {
-                                    Label("Standard Library", systemImage: "list.bullet.clipboard")
-                                }
-
-                                Button { presentCollectionSheet.toggle() } label: {
-                                    Label("Manage Collections", systemImage: "tray.full")
-                                }
-                            }
-
                         } label: {
-                            Image(systemName: "ellipsis.circle")
-                                .imageScale(.large)
+                            HStack {
+                                Text(path.description)
+                                Spacer()
+                                if self.sortKey == path {
+                                    Image(systemName: "checkmark")
+                                        .transition(.scale)
+                                }
+                            }
+
                         }
+                        .tag(path)
                     }
+                } header: {
+                    Text("Sort By")
                 }
-            }
-            .navigationBarTitleDisplayMode(.inline)
-            .conditional(useCompactView, transform: { view in
-                view
-                    .toolbar {
-                        ToolbarItem(placement: .principal) {
-                            CollectionSelectorHeader
+
+                Button {
+                    sortOrder.toggle()
+
+                } label: {
+                    Label("Order", systemImage: sortOrder.ascending ? "arrow.down" : "arrow.up")
+                        .transition(.scale)
+                }
+
+                Section {
+                    Button {
+                        withAnimation {
+                            self.showDownloadsOnly = !self.showDownloadsOnly
                         }
+                    } label: {
+                        HStack {
+                            Text("Downloaded")
+                            Spacer()
+                            if self.showDownloadsOnly {
+                                Image(systemName: "checkmark")
+                                    .transition(.scale)
+                            }
+                        }
+
                     }
-            })
-            .navigationBarTitle(NAV_TITLE)
-            .environmentObject(model)
-            .searchable(text: $model.query, placement: .navigationBarDrawer(displayMode: .always), prompt: Text("Search \(NAV_TITLE)"))
-            .onReceive(model.$query.debounce(for: .seconds(0.15), scheduler: DispatchQueue.main).dropFirst()) { _ in
-                observe()
-            }
-            .sheet(isPresented: $presentOptionsSheet) {
-                OptionsSheet(collection: model.collection)
-            }
-            .sheet(isPresented: $presentStatsSheet, content: {
-                SmartNavigationView {
-                    LoadableStatisticsView()
+                    Button {
+                        withAnimation {
+                            self.filterByTrackedTitles = !self.filterByTrackedTitles
+                        }
+                    } label: {
+                        HStack {
+                            Text("Tracked")
+                            Spacer()
+                            if self.filterByTrackedTitles {
+                                Image(systemName: "checkmark")
+                                    .transition(.scale)
+                            }
+                        }
+
+                    }
+                } header: {
+                    Text("Filter By")
                 }
-            })
-            .fullScreenCover(isPresented: $presentMigrateSheet, content: {
-                PreMigrationView()
-            })
-            .sheet(isPresented: $presentCollectionSheet) {
-                ManageCollectionsView()
+            } label: {
+                Image(systemName: "line.3.horizontal.decrease")
+                    .imageScale(.large)
+            }
+
+            Menu {
+
+                // Select
+                Button {
+                    model.isSelecting = true
+                } label: {
+                    Label("Select", systemImage: "checkmark.circle")
+                }
+
+                Divider()
+
+                if useCompactView {
+                    Button { useCompactView.toggle() } label: {
+                        Label("Standard Library", systemImage: "list.bullet.clipboard")
+                    }
+
+                    Divider()
+                }
+
+
+                Button {
+                    presentOptionsSheet.toggle()
+                } label: {
+                    Label("Edit Collection", systemImage: "gearshape")
+                }
+
+                Button { presentCollectionSheet.toggle() } label: {
+                    Label("Manage Collections", systemImage: "tray.full")
+                }
+
+                Divider()
+
+                Button {
+                    Task {
+                        model.refresh()
+                    }
+                } label: {
+                    Label("Refresh Database", systemImage: "arrow.triangle.2.circlepath")
+                }
+
+                Button {
+                    presentMigrateSheet.toggle()
+                } label: {
+                    Label("Migrate", systemImage: "shippingbox")
+                }
+
+                Button {
+                    presentStatsSheet.toggle()
+                } label: {
+                    Label("Statistics", systemImage: "chart.bar")
+                }
+
+            } label: {
+                Image(systemName: "ellipsis.circle")
+                    .imageScale(.large)
             }
         }
 
         private var NAV_TITLE: String {
             useLibrary ? "Library" : model.collection?.name ?? model.readingFlag?.description ?? "All Titles"
-        }
-
-        private func MainView(_ entries: [LibraryEntry]) -> some View {
-            LibraryGrid.Grid(entries: entries, collection: $model.collection)
-                .modifier(CollectionModifier(selection: $model.navSelection))
-                .modifier(SelectionModifier(entries: entries))
-                .environment(\.libraryIsSelecting, model.isSelecting)
-                .animation(.default, value: entries)
         }
 
         private var CollectionSelectorHeader: some View {
@@ -263,25 +346,19 @@ extension LibraryView {
                     .font(.headline)
                     .foregroundColor(.gray)
 
-                if showDownloadsOnly {
+                if showDownloadsOnly || filterByTrackedTitles || self.model.collection?.filter != nil {
                     HStack {
                         Image(systemName: "exclamationmark.triangle")
                             .frame(width: 20, height: 20, alignment: .center)
                             .scaledToFit()
                             .foregroundColor(.yellow)
-                        Text("Showing Downloaded Titles Only")
+                        Text("One or multiple filters are applied")
                             .fontWeight(.light)
                             .font(.headline)
                             .foregroundColor(.gray)
                     }
                 }
             }
-        }
-
-        private func ViewTitle(count: Int) -> String {
-            let selectionCount = model.isSelecting ? model.selectedIndexes.count : count
-            let selectionString = model.isSelecting ? "Selection" : "Title"
-            return "^[\(selectionCount) \(selectionString)](inflect: true)"
         }
     }
 }

--- a/iOS/Views/Library/Views/LibraryGrid/LibraryGrid+GridView.swift
+++ b/iOS/Views/Library/Views/LibraryGrid/LibraryGrid+GridView.swift
@@ -11,53 +11,96 @@ import SwiftUI
 
 extension LibraryView.LibraryGrid {
     struct Grid: View {
-        var entries: [LibraryEntry]
-        @Binding var collection: LibraryCollection?
         @AppStorage(STTKeys.TileStyle) var style = TileStyle.COMPACT
         @EnvironmentObject var model: LibraryView.LibraryGrid.ViewModel
         @State var manageSelection: String?
+
+        var regularLibrary: [LibraryEntry] {
+            model.regularLibrary ?? []
+        }
+
+        var pinnedLibrary: [LibraryEntry] {
+            model.pinnedLibrary ?? []
+        }
+
+        func getCell(_ entry: LibraryEntry, _ state: ASCellContext) -> some View {
+            ZStack(alignment: .topTrailing) {
+                Button {
+                    model.navSelection = entry
+                } label: {
+                    LibraryView.LibraryGrid.GridTile(entry: entry)
+                }
+                .buttonStyle(NeutralButtonStyle())
+                .disabled(model.isSelecting)
+
+                Image(systemName: "circle.fill")
+                    .resizable()
+                    .foregroundColor(state.isSelected ? .accentColor : .black)
+                    .clipShape(Circle())
+                    .frame(width: 20, height: 20)
+                    .overlay(Circle().stroke(Color.white, lineWidth: 3).shadow(radius: 10))
+                    .padding(.all, 5)
+                    .opacity(model.isSelecting ? 1 : 0)
+            }
+            .animation(.default, value: model.isSelecting)
+            .animation(.default, value: model.selectedPinnedIndexes)
+            .animation(.default, value: model.selectedRegularIndexes)
+        }
+
+        func getPinnedSection() -> ASCollectionViewSection<Int> {
+            ASCollectionViewSection(id: 0,
+                                    data: pinnedLibrary,
+                                    selectionMode: model.isSelecting ? .selectMultiple($model.selectedPinnedIndexes) : .none,
+                                    contextMenuProvider: contextMenuProvider)
+            { entry, state in
+                getCell(entry, state)
+            }
+            .sectionHeader {
+                HStack {
+                    Text("^[\(pinnedLibrary.count) Title](inflect: true)")
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                        .foregroundColor(.gray)
+                    Spacer()
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+            .sectionFooter {
+                EmptyView()
+            }
+        }
+
+        func getRegularSection() -> ASCollectionViewSection<Int> {
+            ASCollectionViewSection(id: 1,
+                                    data: regularLibrary,
+                                    selectionMode: model.isSelecting ? .selectMultiple($model.selectedRegularIndexes) : .none,
+                                    contextMenuProvider: contextMenuProvider)
+            { entry, state in
+                getCell(entry, state)
+            }
+            .sectionHeader {
+                HStack {
+                    Text("^[\(regularLibrary.count) Title](inflect: true)")
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                        .foregroundColor(.gray)
+                    Spacer()
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+            .sectionFooter {
+                EmptyView()
+            }
+        }
+
         var body: some View {
             ASCollectionView(editMode: model.isSelecting) {
-                ASCollectionViewSection(id: 0,
-                                        data: entries,
-                                        selectionMode: model.isSelecting ? .selectMultiple($model.selectedIndexes) : .none,
-                                        contextMenuProvider: contextMenuProvider)
-                { entry, state in
-
-                    ZStack(alignment: .topTrailing) {
-                        Button {
-                            model.navSelection = entry
-                        } label: {
-                            LibraryView.LibraryGrid.GridTile(entry: entry)
-                        }
-                        .buttonStyle(NeutralButtonStyle())
-                        .disabled(model.isSelecting)
-
-                        Image(systemName: "circle.fill")
-                            .resizable()
-                            .foregroundColor(state.isSelected ? .accentColor : .black)
-                            .clipShape(Circle())
-                            .frame(width: 20, height: 20)
-                            .overlay(Circle().stroke(Color.white, lineWidth: 3).shadow(radius: 10))
-                            .padding(.all, 5)
-                            .opacity(model.isSelecting ? 1 : 0)
-                    }
-                    .animation(.default, value: model.isSelecting)
-                    .animation(.default, value: model.selectedIndexes)
+                if !pinnedLibrary.isEmpty {
+                    getPinnedSection()
                 }
-                .sectionHeader(content: {
-                    HStack {
-                        Text("^[\(entries.count) Title](inflect: true)")
-                            .font(.caption)
-                            .fontWeight(.semibold)
-                            .foregroundColor(.gray)
-                        Spacer()
-                    }
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                })
-                .sectionFooter(content: {
-                    EmptyView()
-                })
+                if !regularLibrary.isEmpty {
+                    getRegularSection()
+                }
             }
             .layout {
                 DynamicGridLayout(header: .absolute(22))
@@ -67,7 +110,8 @@ extension LibraryView.LibraryGrid {
             .shouldInvalidateLayoutOnStateChange(true)
             .ignoresSafeArea(.keyboard, edges: .all)
             .animation(.default, value: model.isSelecting)
-            .animation(.default, value: model.selectedIndexes)
+            .animation(.default, value: model.selectedPinnedIndexes)
+            .animation(.default, value: model.selectedRegularIndexes)
             .sheet(item: $manageSelection) { selection in
                 ProfileView.Sheets.LibrarySheet(id: selection)
                     .environmentObject(StateManager.shared)
@@ -116,7 +160,7 @@ extension LibraryView.LibraryGrid {
                 }
 
                 // Remove from Collection
-                if let collection = collection {
+                if let collection = model.collection {
                     let removeFromCollection = UIAction(title: "Remove from Collection", image: .init(systemName: "xmark"), attributes: .destructive) { _ in
                         //
                         let contentId = content.id

--- a/iOS/Views/Library/Views/LibraryGrid/LibraryGrid+GridView.swift
+++ b/iOS/Views/Library/Views/LibraryGrid/LibraryGrid+GridView.swift
@@ -56,9 +56,13 @@ extension LibraryView.LibraryGrid {
                 getCell(entry, state)
             }
             .sectionHeader {
-                HStack {
+                HStack(spacing: 4) {
+                    Image(systemName: "pin.fill")
+                        .font(.footnote)
+                        .rotationEffect(Angle(degrees: -30))
+                        .foregroundColor(.accentColor)
                     Text("^[\(pinnedLibrary.count) Title](inflect: true)")
-                        .font(.caption)
+                        .font(.footnote)
                         .fontWeight(.semibold)
                         .foregroundColor(.gray)
                     Spacer()

--- a/iOS/Views/Library/Views/LibraryGrid/Sheets/LG+MoveCollection.swift
+++ b/iOS/Views/Library/Views/LibraryGrid/Sheets/LG+MoveCollection.swift
@@ -60,13 +60,16 @@ extension LibraryView.LibraryGrid {
                     ToolbarItem(placement: .confirmationAction) {
                         Button("Done") {
                             ToastManager.shared.loading.toggle()
-                            let targets = zip(entries.indices, entries)
-                                .filter { model.selectedIndexes.contains($0.0) }
-                                .map { $0.1.id }
+
+                            model.clearSelection()
+
+                            let targets = entries
+                                .map { $0.id }
                             Task {
                                 let actor = await Suwatte.RealmActor.shared()
                                 await actor.moveToCollections(entries: Set(targets), cids: selectedCollections)
                             }
+
                             ToastManager.shared.loading.toggle()
                             presentationMode.wrappedValue.dismiss()
                         }

--- a/iOS/Views/Library/Views/LibraryGrid/Sheets/LG+MoveFlag.swift
+++ b/iOS/Views/Library/Views/LibraryGrid/Sheets/LG+MoveFlag.swift
@@ -55,9 +55,9 @@ extension LibraryView.LibraryGrid {
         }
 
         func setFlags(_ flag: LibraryFlag) {
-            let targets = zip(entries.indices, entries)
-                .filter { model.selectedIndexes.contains($0.0) }
-                .map { $0.1.id }
+            model.clearSelection()
+            let targets = entries
+                .map { $0.id }
             let ids = Set(targets)
             Task {
                 let actor = await Suwatte.RealmActor.shared()

--- a/iOS/Views/Library/Views/LibraryGrid/Sheets/LibraryGrid+OptionsSheet.swift
+++ b/iOS/Views/Library/Views/LibraryGrid/Sheets/LibraryGrid+OptionsSheet.swift
@@ -6,6 +6,8 @@
 //
 
 import SwiftUI
+import RealmSwift
+
 enum LibraryBadge: Int, CaseIterable {
     case unread, update
 
@@ -22,36 +24,56 @@ extension LibraryView.LibraryGrid {
         @AppStorage(STTKeys.LibraryShowBadges) var showBadges = true
         @AppStorage(STTKeys.LibraryBadgeType) var badgeType: LibraryBadge = .update
         @AppStorage(STTKeys.ShowOnlyDownloadedTitles) var showDownloadsOnly = false
-        var collection: LibraryCollection?
+        @AppStorage(STTKeys.LibraryPinningType) var pinningType: TitlePinningType = .unread
+        @AppStorage(STTKeys.LibraryEnableTitlePinning) var enableTitlePinning = false
+        @EnvironmentObject var model: LibraryView.LibraryGrid.ViewModel
+
         var body: some View {
-            SmartNavigationView {
-                List {
-                    Section {
-                        Toggle("Show Badges", isOn: $showBadges)
-                        if showBadges {
-                            Picker("Badge Type", selection: $badgeType) {
-                                ForEach(LibraryBadge.allCases, id: \.rawValue) {
-                                    Text($0.description)
-                                        .tag($0)
-                                }
+            List {
+                Section {
+                    Toggle("Show Badges", isOn: $showBadges)
+                    if showBadges {
+                        Picker("Badge Type", selection: $badgeType) {
+                            ForEach(LibraryBadge.allCases, id: \.rawValue) {
+                                Text($0.description)
+                                    .tag($0)
                             }
                         }
-                        Toggle("Show Only Downloaded Titles", isOn: $showDownloadsOnly)
                     }
 
-                    Section {
-                        if let collection = collection?.thaw() {
-                            NavigationLink("Collection Settings") {
-                                CollectionManagementView(collection: collection, collectionName: collection.name)
+                    Toggle("Pin Titles", isOn: $enableTitlePinning)
+                    if enableTitlePinning {
+                        HStack {
+                            Text("Pin Type")
+                            Spacer()
+                            Picker("", selection: $pinningType) {
+                                ForEach(TitlePinningType.pinTypes, id: \.self) {
+                                    Text($0.description)
+                                }
                             }
+                            .pickerStyle(.segmented)
+                            .fixedSize()
                         }
                     }
+                } header: {
+                    Text("Global Settings")
                 }
-                .navigationTitle("Settings")
-                .navigationBarTitleDisplayMode(.inline)
-                .animation(.default, value: showBadges)
-                .closeButton()
+
+                if let collection = model.collection?.thaw() {
+                    Section {
+
+                    } header: {
+                        Text("Collection Settings")
+                    }
+
+                    CollectionManagementView(collection: collection, collectionName: collection.name)
+                }
             }
+            .navigationTitle("Collection Settings")
+            .navigationBarTitleDisplayMode(.inline)
+            .animation(.default, value: showBadges)
+            .animation(.default, value: enableTitlePinning)
+            .closeButton()
         }
     }
 }

--- a/iOS/Views/More/Settings/SettingsView.swift
+++ b/iOS/Views/More/Settings/SettingsView.swift
@@ -33,13 +33,11 @@ extension SettingsView {
     struct MiscSection: View {
         private let options = AppTabs.defaultSettings
         @AppStorage(STTKeys.IntialTabIndex) var InitialSelection = 3
-        @AppStorage(STTKeys.OpenAllTitlesOnAppear) var openAllOnAppear = false
+
         var body: some View {
             Section {
                 // Initial Opening Tab
                 OpeningTab
-                Toggle("Open Default Collection", isOn: $openAllOnAppear)
-
             } header: {
                 Text("Tabs")
             }
@@ -246,6 +244,8 @@ extension SettingsView {
         @AppStorage(STTKeys.AlwaysAskForLibraryConfig) private var alwaysAsk = true
         @AppStorage(STTKeys.DefaultCollection) var defaultCollection: String = ""
         @AppStorage(STTKeys.DefaultReadingFlag) var defaultFlag = LibraryFlag.unknown
+        @AppStorage(STTKeys.OpenDefaultCollectionEnabled) var openDefaultCollectionOnAppear = false
+        @AppStorage(STTKeys.OpenDefaultCollection) var defaultCollectionToOpen: String = ""
         @EnvironmentObject private var stateManager: StateManager
 
         private var collections: [LibraryCollection] {
@@ -254,8 +254,25 @@ extension SettingsView {
 
         var body: some View {
             Section {
-                Toggle("Always Prompt", isOn: $alwaysAsk)
+                Toggle("Open Default Collection", isOn: $openDefaultCollectionOnAppear)
+                if openDefaultCollectionOnAppear {
+                    Picker("Default Collection", selection: .init($defaultCollectionToOpen, deselectTo: "-1")) {
+                        Text("All Titles")
+                            .tag("-1")
+                        ForEach(collections) {
+                            Text($0.name)
+                                .tag($0.id)
+                        }
+                    }
+                    .transition(.slide)
+                }
+            } header: {
+                Text("Library - Navigation")
+            }
+            .animation(.default, value: openDefaultCollectionOnAppear)
 
+            Section {
+                Toggle("Open prompt when adding titles", isOn: $alwaysAsk)
                 if !alwaysAsk {
                     Picker("Default Collection", selection: .init($defaultCollection, deselectTo: "")) {
                         Text("None")
@@ -278,7 +295,7 @@ extension SettingsView {
                     .transition(.slide)
                 }
             } header: {
-                Text("Library")
+                Text("Library - Data")
             }
             .animation(.default, value: alwaysAsk)
         }


### PR DESCRIPTION
* Fixed SmartFilter isNSFW
* Fixed SmartFilter ContentType
* Added Logical Operator for SmartFilter
* Add quick filter for tracked Titles
* Add quick filter for downloaded Titles
* Add pinning titles by unread and updated titles per collection and also global
* Fixed startup flickering when having a default collection selected for standard library
* Rework Collection Settings View
* Fix Edit button being stuck in Manage Collections View
* Fix "invert selection" option when selecting titles
* Fix library being updated when exiting the collection setting view
* Add a sorting/filter button and reorder the existing menu items
* Remove the existing "Open first default Collection" Setting
* Add Open Default Collection Settings which makes it possible to choose from your existing collections
