### PR TITLE
Fix Self Migration

### DIFF
--- a/iOS/Views/Migrate/Migration+ViewModel.swift
+++ b/iOS/Views/Migrate/Migration+ViewModel.swift
@@ -346,7 +346,10 @@ extension MigrationController {
             
             // CRUD
             realm.add(object, update: .all)
-            entry.isDeleted = true
+            
+            if object.id != entry.id {
+                entry.isDeleted = true
+            }
         }
 
         func findOrCreate(_ entry: TaggedHighlight) -> StoredContent {


### PR DESCRIPTION
Only delete when the replacement object does not match the current object.