### PR TITLE
fix: Stop using lexical sort for numerical filenames and instead parse out the number

### DIFF
--- a/iOS/Models/SourceDownloadManager/SDM.swift
+++ b/iOS/Models/SourceDownloadManager/SDM.swift
@@ -209,7 +209,7 @@ extension SDM {
                 .contentsOfDirectory(at: url, includingPropertiesForKeys: nil)
             let imageUrls = directoryContents
                 .filter { imageExtensions.contains($0.pathExtension) }
-                .sorted(by: \.fileName, descending: false)
+                .sorted { (Int($0.fileName) ?? 0) < (Int($1.fileName) ?? 0) }
 
             data.urls = imageUrls
             return data


### PR DESCRIPTION
Fixes out of order pages in downloads; ex: `"100" < "99"` but `99 < 100`. esp made worse because `.issue` in SDM uses leading zero for single digits.