### PR TITLE
Batch and debounce iCloud sync

### DIFF
--- a/iOS/Singletons/AppDelegate.swift
+++ b/iOS/Singletons/AppDelegate.swift
@@ -22,6 +22,10 @@ class STTAppDelegate: NSObject, UIApplicationDelegate {
         // Set Default UD Values
         UserDefaults.standard.register(defaults: STTUserDefaults())
         UDSync.sync()
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(handleUserDefaultsChange),
+                                               name: UserDefaults.didChangeNotification,
+                                               object: nil)
 
         // Nuke Requests
         let nukeConfig = DataLoader.defaultConfiguration
@@ -64,5 +68,15 @@ class STTAppDelegate: NSObject, UIApplicationDelegate {
         FirebaseApp.configure()
 
         return true
+    }
+    
+    func applicationWillTerminate(_ application: UIApplication) {
+        NotificationCenter.default.removeObserver(self,
+                                                  name: UserDefaults.didChangeNotification,
+                                                  object: nil)
+    }
+
+    @objc private func handleUserDefaultsChange(_ notification: Notification) {
+        UDSync.sync()
     }
 }


### PR DESCRIPTION
**Untested change as my personal account does not have the right entitlements for iCloud or push notifications.** 

Change is quite simple by itself:
- Debounce updates by 30 seconds
- Static keys are batched by 10
- Dynamic keys are batched by 5
- On app start we watch for changes and begin the syncing process

On discord it was hinted that there is a chance that iCloud sync works again without any adjustments. With the debounce and batching there is pretty much a guarantee that devices no longer get overloaded. As I cannot test, feel free to use this PR to make adjustments to get it to mergeable state! 