### PR TITLE
fix[runner]: handle WKWebView process termination to prevent RunnerObject loss

### DIFF
--- a/iOS/Daisuke/Engine/Bootstrap/Engine+WK.swift
+++ b/iOS/Daisuke/Engine/Bootstrap/Engine+WK.swift
@@ -68,10 +68,10 @@ extension DSK {
             window?.addSubview(wv)
             let bootstrapper = WKBootstrapper(wv: wv)
             await bootstrapper.prepare()
-            return wv
+            return (wv, bootstrapper)
         }
 
-        let wv = await task.value
+        let (wv, bootstrapper) = await task.value
 
         let environment = try await wv
             .evaluateJavaScript("(function(){ return RunnerEnvironment })()", contentWorld: .defaultClient)
@@ -92,6 +92,7 @@ extension DSK {
             throw DSK.Errors.NamedError(name: "Engine", message: "Failed to recognize runner environment.")
         }
 
+        runner.setBootstrapper(bootstrapper)
         return runner
     }
 }

--- a/iOS/Daisuke/Environments/WKRunnerEnvironment/Runners/WKRunner/WKRunner.swift
+++ b/iOS/Daisuke/Environments/WKRunnerEnvironment/Runners/WKRunner/WKRunner.swift
@@ -13,6 +13,7 @@ public class WKRunner: DSKRunner {
     var intents: RunnerIntents
     let wv: WKWebView!
     var configCache: [String: DSKCommon.DirectoryConfig] = [:]
+    var bootstrapper: WKBootstrapper?
 
     var customID: String?
     var customName: String?
@@ -43,6 +44,10 @@ public class WKRunner: DSKRunner {
         saveState()
     }
 
+    func setBootstrapper(_ bootstrapper: WKBootstrapper) {
+        self.bootstrapper = bootstrapper
+    }
+
     func handleURL(url: String) async throws -> DSKCommon.DeepLinkContext? {
         try await eval(script("let data = await RunnerObject.handleURL(url)"),
                        ["url": url])
@@ -53,6 +58,8 @@ class WKBootstrapper: NSObject {
     private weak var wv: WKWebView?
     var isClientReady = false
     fileprivate var continuation: CheckedContinuation<Void, Never>?
+    private var hasSetupDelegate = false
+
     init(wv: WKWebView) {
         self.wv = wv
         super.init()
@@ -74,6 +81,22 @@ class WKBootstrapper: NSObject {
 
     @MainActor
     func prepare() async {
+        // Set up navigation delegate to handle process termination
+        if !hasSetupDelegate {
+            wv?.navigationDelegate = self
+            hasSetupDelegate = true
+        }
+
+        wv?.configuration.userContentController.add(self, contentWorld: .defaultClient, name: "state")
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+            wv?.loadHTMLString(HTML, baseURL: nil)
+        }
+    }
+
+    @MainActor
+    func reload() async {
+        isClientReady = false
         wv?.configuration.userContentController.add(self, contentWorld: .defaultClient, name: "state")
         await withCheckedContinuation { continuation in
             self.continuation = continuation
@@ -88,7 +111,6 @@ extension WKBootstrapper: WKScriptMessageHandler {
         continuation?.resume()
         continuation = nil
         wv?.configuration.userContentController.removeScriptMessageHandler(forName: "state", contentWorld: .defaultClient)
-        wv = nil
     }
 
     func userContentController(_: WKUserContentController, didReceive message: WKScriptMessage) {
@@ -99,6 +121,16 @@ extension WKBootstrapper: WKScriptMessageHandler {
             didEnterReadyState()
         default:
             break
+        }
+    }
+}
+
+extension WKBootstrapper: WKNavigationDelegate {
+    @MainActor
+    func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+        Logger.shared.log("WKWebView process terminated, reloading...")
+        Task {
+            await reload()
         }
     }
 }


### PR DESCRIPTION
## Summary
  - Fixes WKWebView runner throwing "JS Error: Can't find variable: RunnerObject" after app returns from background
  - Implements automatic WebView reload when iOS terminates the content process

  ## Problem
  When the app is sent to background, iOS may terminate WKWebView's content process to free memory. When the app returns to foreground and tries to access runner browse pages, the JavaScript environment has
  been lost, causing `RunnerObject` to be undefined.

  ## Solution
  - Added `WKNavigationDelegate` to `WKBootstrapper` to detect process termination via `webViewWebContentProcessDidTerminate`
  - Implemented automatic reload mechanism that reinitializes the WebView HTML and scripts
  - Keep bootstrapper reference alive in `WKRunner` to maintain the delegate connection
  - Added `reload()` method to handle reinitialization