### PR TITLE
fix[library]: respect "Open prompt when adding titles" setting

### DIFF
--- a/iOS/Views/Profile/Body/Components/ProfileView+Header.swift
+++ b/iOS/Views/Profile/Body/Components/ProfileView+Header.swift
@@ -197,10 +197,11 @@ private extension Skeleton {
                 STTHelpers.triggerHaptic(true)
             }
             let ids = model.STTIDPair
-            if !EntryInLibrary {
+            let wasInLibrary = EntryInLibrary
+            if !wasInLibrary {
                 await actor.toggleLibraryState(for: ids)
             }
-            if promptForConfig || EntryInLibrary {
+            if promptForConfig || wasInLibrary {
                 model.presentCollectionsSheet.toggle()
             } else {
                 if !defaultCollection.isEmpty {


### PR DESCRIPTION
 ## Summary

  Fixed a bug where the library collection prompt would still appear when adding new titles, even when the "Open prompt when adding titles" setting was disabled.

  ## Root Cause

  The code was checking the library membership status (EntryInLibrary) after already adding the title to the library, causing the condition to incorrectly trigger the prompt for newly added titles.

  ## Changes

  - Capture the library state before toggling (wasInLibrary)
  - Use the original state to determine whether to show the prompt, ensuring the setting is respected for new additions