### PR TITLE
fix[sync]: sync individual read chapters when max chapter matches local

### DIFF
--- a/iOS/Views/Profile/ViewModel/CPVM+Sync.swift
+++ b/iOS/Views/Profile/ViewModel/CPVM+Sync.swift
@@ -110,7 +110,7 @@ extension ViewModel {
         })
 
         // Update Local Value if outdated, sources are notified if they have the Chapter Event Handler
-        guard maxReadChapter != localHighestRead else { return }
+        guard maxReadChapter != localHighestRead || !readIDs.isEmpty else { return }
 
         let markIndividually = maxReadChapter == sourceOriginHighestRead && !readIDs.isEmpty
 


### PR DESCRIPTION
## Background:

  When using third-party runners with getProgressState to sync reading progress, there was an edge case where individual read chapters were not being synced properly.

##  Issue Scenario:

  1. User has chapter 7 marked as read locally (already synced to source)
  2. User reads chapters 1, 2, 3 on another device/platform
  3. Source returns readChapterIds = [1, 2, 3, 7] via getProgressState
  4. The sync logic calculated that the maximum read chapter from the source (7) matched the local highest read chapter (7)
  5. Because these values matched, the sync process returned early without marking chapters 1, 2, 3 as read locally

 ## Root Cause:

  The sync guard condition only checked if the maximum read chapter number differed from local, which prevented syncing when the highest chapter numbers matched, even though there were individual chapters that
  needed to be marked as read.

 ## Solution:

  Modified the guard condition to allow sync to proceed when either:
  - The max read chapter differs from local (original behavior)
  - There are individual read chapter IDs to process (fixes the bug)

  The existing filter logic already prevents re-marking already completed chapters, so this change has no adverse side effects.