### PR TITLE
fix[profile]: prevent cover tap gesture from blocking library button

### DIFF
--- a/iOS/Views/Profile/Body/Components/ProfileView+Header.swift
+++ b/iOS/Views/Profile/Body/Components/ProfileView+Header.swift
@@ -104,6 +104,7 @@ extension Skeleton.Header {
             .frame(width: ImageWidth, height: ImageWidth * 1.5)
             .cornerRadius(7)
             .shadow(radius: 3)
+            .contentShape(Rectangle())
             .onTapGesture {
                 presentThumbnails.toggle()
             }


### PR DESCRIPTION
 ## Summary

  Fix cover image tap gesture blocking library button on content profile page when cover is large.

##  Problem

  In the ProfileView header, the cover image's onTapGesture hit area extends beyond its visual boundary in some cases, overlapping with the action buttons on the right (including Library, Tracker buttons,
  etc.). This causes users to accidentally trigger the cover preview when attempting to click the buttons, preventing them from adding content to their library.

##  Solution

  Add .contentShape(Rectangle()) before the cover image's onTapGesture to strictly constrain the tap area to the cover's frame bounds (150x225), ensuring the gesture doesn't extend beyond its boundary and
  interfere with other UI elements.