### PR TITLE
fix[profile]: prevent fullScreenCover from dismissing when app returns from background

### DIFF
--- a/iOS/Views/Main/ContentView.swift
+++ b/iOS/Views/Main/ContentView.swift
@@ -17,18 +17,7 @@ struct ContentView: View {
     @Environment(\.scenePhase) private var scenePhase
 
     var body: some View {
-        MainContent
-            .onChange(of: scenePhase) { phase in
-                switch phase {
-                case .background:
-                    STTScheduler.shared.scheduleAll()
-                default: break
-                }
-                appState.didScenePhaseChange(phase)
-            }
-            .onAppear {
-                selection = InitialSelection
-            }
+        ContentViewContainer
             .fullScreenCover(item: $navModel.content) { taggedHighlight in
                 SmartNavigationView {
                     ProfileView(entry: taggedHighlight.highlight, sourceId: taggedHighlight.sourceID)
@@ -51,11 +40,28 @@ struct ContentView: View {
                               pageOffset: ctx.requestedOffset)
                     .onDisappear(perform: ctx.dismissAction)
             }
-            .task {
-                await startup()
+    }
+
+    var ContentViewContainer: some View {
+        ZStack {
+            MainContent
+                .onAppear {
+                    selection = InitialSelection
+                }
+                .task {
+                    await startup()
+                }
+                .environmentObject(toaster)
+                .environmentObject(appState)
+        }
+        .onChange(of: scenePhase) { phase in
+            switch phase {
+            case .background:
+                STTScheduler.shared.scheduleAll()
+            default: break
             }
-            .environmentObject(toaster)
-            .environmentObject(appState)
+            appState.didScenePhaseChange(phase)
+        }
     }
 
     var MainContent: some View {


### PR DESCRIPTION
### Problem Description

When switching back to the app from another app, fullscreen presentations (including content detail pages and the manga reader) would automatically dismiss and navigate back to the home screen, disrupting the user experience.

### Root Cause Analysis

The issue was caused by the view modifier structure where both the scene phase observer and fullScreenCover modifiers were directly attached to the same view layer. When the app returned from background, the scenePhase change triggered a view hierarchy re-evaluation that inadvertently dismissed all active fullScreenCover presentations.

### Solution

Restructured the view hierarchy by introducing a container layer (`ContentViewContainer`) that isolates the scene phase handling from the content presentation. This separation ensures that fullScreenCover presentations remain stable when the app transitions between background and foreground states.

### Affected Components

This fix resolves the issue for all fullScreenCover presentations:
- ✅ Content detail pages (ProfileView)
- ✅ Manga reader interface (ReaderGateWay)
- ✅ Page link views (PageLinkView)