### PR TITLE
fix[library]: correct sort order arrow direction in library view

### DIFF
--- a/iOS/Views/Library/Views/LibraryGrid/Library+CollectionView.swift
+++ b/iOS/Views/Library/Views/LibraryGrid/Library+CollectionView.swift
@@ -178,7 +178,7 @@ extension LibraryView {
                     sortOrder.toggle()
 
                 } label: {
-                    Label("Order", systemImage: sortOrder.ascending ? "arrow.down" : "arrow.up")
+                    Label("Order", systemImage: sortOrder.ascending ? "arrow.up" : "arrow.down")
                         .transition(.scale)
                 }
 


### PR DESCRIPTION
- Ascending order shows arrow up ↑
- Descending order shows arrow down ↓