### PR TITLE
fix[paging]: disable double tap to reduce tap delay

### DIFF
--- a/iOS/Views/Reader/Viewers/ImageViewer/Views/UIKit/Controllers/PagingController/PagingController+Gesture.swift
+++ b/iOS/Views/Reader/Viewers/ImageViewer/Views/UIKit/Controllers/PagingController/PagingController+Gesture.swift
@@ -14,10 +14,6 @@ private typealias Controller = IVPagingController
 extension Controller {
     func addTapGestures() {
         let tapGR = UITapGestureRecognizer(target: self, action: #selector(handleTap(_:)))
-        let doubleTapGR = UITapGestureRecognizer(target: self, action: #selector(handleDoubleTap(_:)))
-        doubleTapGR.numberOfTapsRequired = 2
-        tapGR.require(toFail: doubleTapGR)
-        collectionView.addGestureRecognizer(doubleTapGR)
         collectionView.addGestureRecognizer(tapGR)
     }
 
@@ -28,10 +24,6 @@ extension Controller {
 
         let location = sender.location(in: view)
         handleNavigation(at: location)
-    }
-
-    @objc private func handleDoubleTap(_: UITapGestureRecognizer? = nil) {
-        // Do Nothing
     }
 }
 

--- a/iOS/Views/Reader/Viewers/ImageViewer/Views/UIKit/Controllers/WebtoonController/WebtoonController+Gesture.swift
+++ b/iOS/Views/Reader/Viewers/ImageViewer/Views/UIKit/Controllers/WebtoonController/WebtoonController+Gesture.swift
@@ -13,15 +13,9 @@ extension Controller {
     func addGestures() {
         let tapGR = UITapGestureRecognizer(target: self,
                                            action: #selector(handleTap(_:)))
-        let doubleTapGR = UITapGestureRecognizer(target: self,
-                                                 action: #selector(handleDoubleTap(_:)))
         let longPressGesture = UILongPressGestureRecognizer(target: self, action: #selector(handleLongPress(gesture:)))
 
-        doubleTapGR.numberOfTapsRequired = 2
-        tapGR.require(toFail: doubleTapGR)
-
         collectionNode.view.addGestureRecognizer(longPressGesture)
-        collectionNode.view.addGestureRecognizer(doubleTapGR)
         collectionNode.view.addGestureRecognizer(tapGR)
     }
 
@@ -33,22 +27,6 @@ extension Controller {
 
         let location = sender.location(in: navigationController?.view)
         handleNavigation(at: location)
-    }
-
-    @objc func handleDoubleTap(_ sender: UITapGestureRecognizer? = nil) {
-        cancelAutoScroll()
-        guard let sender else {
-            return
-        }
-
-        let point = sender.location(in: view)
-        let path = collectionNode.indexPathForItem(at: point)
-        let node = path.flatMap(collectionNode.nodeForItem(at:)) as? ImageNode
-        guard let node, let path = node.indexPath else { return }
-
-        isZooming = true
-        let location = sender.location(in: node.view)
-        cellTappedAt(point: location, frame: node.view.frame, path: path)
     }
 
     @objc func handleLongPress(gesture _: UILongPressGestureRecognizer) {


### PR DESCRIPTION
### Problem
Tapping on the screen to navigate pages in the reader had a noticeable ~1 second delay, making the app feel sluggish and impacting the reading experience.

### Root Cause
The tap gesture recognizer was configured to wait for a potential double-tap gesture to fail before triggering, causing iOS to wait ~300-500ms to determine if a second tap would occur.

### Solution
- Removed unused double-tap gesture handling from both paging and webtoon controllers
- Eliminated the tap-to-fail dependency, allowing tap gestures to trigger immediately
- Preserved long-press gesture for context menu functionality

### Impact
✅ Tap navigation now responds instantly without any delay  
✅ Improved reading experience across all reading modes  
✅ No breaking changes to existing functionality
