### PR TITLE
fix[navigation]: migrate to NavigationStack to resolve NavigationView stability issues

### DIFF
--- a/Suwatte.xcodeproj/project.pbxproj
+++ b/Suwatte.xcodeproj/project.pbxproj
@@ -3171,7 +3171,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -3230,7 +3230,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -3268,7 +3268,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -3316,7 +3316,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -3349,7 +3349,7 @@
 				INFOPLIST_FILE = ThumbnailProvider/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = ThumbnailProvider;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -3378,7 +3378,7 @@
 				INFOPLIST_FILE = ThumbnailProvider/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = ThumbnailProvider;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/iOS/State/TabBar.swift
+++ b/iOS/State/TabBar.swift
@@ -85,9 +85,11 @@ enum AppTabs: Int, CaseIterable {
 
 struct SmartNavigationView<Content>: View where Content: View {
     let content: () -> Content
+    @State private var navigationPath = NavigationPath()
 
     var body: some View {
-        NavigationView(content: content)
-            .navigationViewStyle(.stack)
+        NavigationStack(path: $navigationPath) {
+            content()
+        }
     }
 }

--- a/iOS/Views/ContentLink/AddContentLink.swift
+++ b/iOS/Views/ContentLink/AddContentLink.swift
@@ -119,7 +119,7 @@ struct AddContentLink: View {
     }
 
     func handleSelection(_ h: DSKCommon.Highlight, _ s: String, _ sn: String) {
-        selection = (sourceId: s, sourceName: sn, entry: h)
+        selection = HighlightIdentifier(sourceId: s, sourceName: sn, entry: h)
         isPresenting.toggle()
     }
 }

--- a/iOS/Views/Daisuke/Misc/DSKHighlightTile.swift
+++ b/iOS/Views/Daisuke/Misc/DSKHighlightTile.swift
@@ -144,7 +144,7 @@ extension DSKHighlightTile {
         if data.link != nil {
             presentLink.toggle()
         } else {
-            selection = (source.id, nil, data)
+            selection = HighlightIdentifier(sourceId: source.id, sourceName: nil, entry: data)
         }
     }
 }

--- a/iOS/Views/Feed/UpdateFeedView.swift
+++ b/iOS/Views/Feed/UpdateFeedView.swift
@@ -57,7 +57,7 @@ struct UpdateFeedView: View {
                             StateManager.shared.stream(item: highlight, sourceId: content.sourceId)
                         } else {
                             selection = nil
-                            selection = (content.sourceId, nil, highlight)
+                            selection = HighlightIdentifier(sourceId: content.sourceId, sourceName: nil, entry: highlight)
                         }
                     }
                     .id(entry.hashValue)

--- a/iOS/Views/Helpers/Modifiers/InteractableContent.swift
+++ b/iOS/Views/Helpers/Modifiers/InteractableContent.swift
@@ -8,73 +8,93 @@
 import RealmSwift
 import SwiftUI
 
+struct ProfileNavigationDestination: Hashable {
+    let entryId: String
+    let entryTitle: String
+    let entryCover: String
+    let sourceId: String
+
+    init(entry: DaisukeEngine.Structs.Highlight, sourceId: String) {
+        self.entryId = entry.id
+        self.entryTitle = entry.title
+        self.entryCover = entry.cover
+        self.sourceId = sourceId
+    }
+
+    func toHighlight() -> DaisukeEngine.Structs.Highlight {
+        DaisukeEngine.Structs.Highlight(id: entryId, cover: entryCover, title: entryTitle)
+    }
+}
+
 struct InteractableContent: ViewModifier {
-    @State var isActive = false
     var entry: DaisukeEngine.Structs.Highlight
     var sourceId: String
     @Environment(\.redactionReasons) var reasons
     func body(content: Content) -> some View {
-        NavigationLink {
-            ProfileView(entry: entry, sourceId: sourceId)
-        } label: {
+        NavigationLink(value: ProfileNavigationDestination(entry: entry, sourceId: sourceId)) {
             content
         }
         .buttonStyle(NeutralButtonStyle())
     }
 }
 
-typealias HighlightIdentifier = (sourceId: String, sourceName: String?, entry: DaisukeEngine.Structs.Highlight)
+struct HighlightIdentifier: Equatable {
+    var sourceId: String
+    var sourceName: String?
+    var entry: DaisukeEngine.Structs.Highlight
+}
 
 struct InteractableContainer: ViewModifier {
-    @State private var isActive = false
     @Binding var selection: HighlightIdentifier?
+    @State private var isNavigating = false
+    @State private var destination: ProfileNavigationDestination?
+
     func body(content: Content) -> some View {
         content
-            .background(
-                Group {
-                    if let selection = selection {
-                        HiddenLink(sourceId: selection.sourceId, entry: selection.entry)
+            .navigationDestination(isPresented: $isNavigating) {
+                if let destination = destination {
+                    ProfileView(entry: destination.toHighlight(), sourceId: destination.sourceId)
+                }
+            }
+            .onChange(of: selection) { newSelection in
+                if let newSelection = newSelection {
+                    destination = ProfileNavigationDestination(entry: newSelection.entry, sourceId: newSelection.sourceId)
+                    isNavigating = true
+                    // Clear after navigation is initiated
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                        selection = nil
                     }
                 }
-            )
-            .onChange(of: selection?.entry) { _ in
-                isActive.toggle()
+            }
+            .onChange(of: isNavigating) { navigating in
+                if !navigating {
+                    destination = nil
+                }
             }
             .onAppear {
                 selection = nil
             }
     }
-
-    func HiddenLink(sourceId: String, entry: DaisukeEngine.Structs.Highlight) -> some View {
-        NavigationLink(isActive: $isActive,
-                       destination: {
-                           ProfileView(entry: entry, sourceId: sourceId)
-                       },
-                       label: { EmptyView() })
-            .buttonStyle(.plain)
-            .frame(width: 0)
-            .opacity(0)
-    }
 }
 
-struct V1<A: View>: ViewModifier {
-    typealias V = A
-    @Binding var isActive: Bool
-    var child: () -> A
+// MARK: - Hidden Navigation (NavigationStack compatible)
+
+struct HiddenNavigationModifier<Destination: View>: ViewModifier {
+    @Binding var isPresented: Bool
+    @ViewBuilder var destination: () -> Destination
+
     func body(content: Content) -> some View {
         content
-            .background {
-                NavigationLink(isActive: $isActive) {
-                    child()
-                } label: {
-                    EmptyView()
-                }
+            .navigationDestination(isPresented: $isPresented) {
+                destination()
             }
     }
 }
 
 extension View {
+    /// Hidden navigation helper compatible with NavigationStack
+    /// Use this for programmatic navigation triggered by state changes
     func hiddenNav<T: View>(presenting: Binding<Bool>, @ViewBuilder _ view: @escaping () -> T) -> some View {
-        modifier(V1(isActive: presenting, child: view))
+        modifier(HiddenNavigationModifier(isPresented: presenting, destination: view))
     }
 }

--- a/iOS/Views/History/HistoryView.swift
+++ b/iOS/Views/History/HistoryView.swift
@@ -137,7 +137,7 @@ extension HistoryView {
             if content.streamable {
                 StateManager.shared.stream(item: content.toHighlight(), sourceId: content.sourceId)
             } else {
-                model.csSelection = (content.sourceId, nil, content.toHighlight())
+                model.csSelection = HighlightIdentifier(sourceId: content.sourceId, sourceName: nil, entry: content.toHighlight())
             }
         } else if let content = marker.chapter?.opds {
             content.read()

--- a/iOS/Views/Library/Views/LibraryGrid/LibraryGrid+ProfileModifier.swift
+++ b/iOS/Views/Library/Views/LibraryGrid/LibraryGrid+ProfileModifier.swift
@@ -8,60 +8,66 @@
 import SwiftUI
 
 extension LibraryView.LibraryGrid {
+    // Navigation destination for NavigationStack
+    struct ProfileDestination: Hashable {
+        let contentId: String
+        let sourceId: String
+        let title: String
+        let cover: String
+
+        init(from content: StoredContent) {
+            self.contentId = content.contentId
+            self.sourceId = content.sourceId
+            self.title = content.title
+            self.cover = content.cover
+        }
+
+        func toHighlight() -> DaisukeEngine.Structs.Highlight {
+            DaisukeEngine.Structs.Highlight(id: contentId, cover: cover, title: title)
+        }
+    }
+
     struct CollectionModifier: ViewModifier {
         @Binding var selection: LibraryEntry?
         @EnvironmentObject var model: ViewModel
-        @State var isActive = false
+        @State private var isNavigating = false
+        @State private var destination: ProfileDestination?
+
         func body(content: Content) -> some View {
             content
-                .background(HiddenLink)
-                .onChange(of: selection) { val in
-                    if val != nil {
-                        isActive.toggle()
+                .navigationDestination(isPresented: $isNavigating) {
+                    if let destination = destination {
+                        ProfileView(entry: destination.toHighlight(), sourceId: destination.sourceId)
                     }
                 }
-        }
-
-        @ViewBuilder
-        var HiddenLink: some View {
-            if let content = selection?.content {
-                NavigationLink(isActive: $isActive,
-                               destination: {
-                                   LazyView(ProfileView(entry: content.toHighlight(), sourceId: content.sourceId))
-
-                               },
-                               label: { EmptyView() })
-                    .onChange(of: isActive) { newValue in
-                        if !newValue {
-                            selection = nil
-                        }
+                .onChange(of: selection) { entry in
+                    guard let entry = entry, let content = entry.content else { return }
+                    destination = ProfileDestination(from: content)
+                    isNavigating = true
+                    // Clear selection after navigation is initiated
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                        selection = nil
                     }
-                    .buttonStyle(NeutralButtonStyle())
-                    .disabled(model.isSelecting)
-            }
+                }
+                .onChange(of: isNavigating) { navigating in
+                    if !navigating {
+                        destination = nil
+                    }
+                }
         }
     }
 
     struct ProfileModifier: ViewModifier {
-        @State var isActive = false
         var entry: LibraryEntry
+
         func body(content: Content) -> some View {
-            content
-                .onTapGesture {
-                    isActive.toggle()
-                }
-                .background(HiddenLink)
-        }
-
-        @ViewBuilder
-        var HiddenLink: some View {
             if let readable = entry.content {
-                NavigationLink(isActive: $isActive,
-                               destination: {
-                                   LazyView(ProfileView(entry: readable.toHighlight(), sourceId: readable.sourceId))
-
-                               },
-                               label: { EmptyView() })
+                NavigationLink(value: ProfileDestination(from: readable)) {
+                    content
+                }
+                .buttonStyle(.plain)
+            } else {
+                content
             }
         }
     }

--- a/iOS/Views/More/MoreView.swift
+++ b/iOS/Views/More/MoreView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct MoreView: View {
     var body: some View {
-        NavigationView {
+        SmartNavigationView {
             List {
                 // TODO: UserProfileHeader
                 GeneralSection
@@ -19,8 +19,6 @@ struct MoreView: View {
             }
             .listStyle(.insetGrouped)
             .navigationTitle("More")
-
-            SettingsView()
         }
     }
 

--- a/iOS/Views/Profile/Body/Components/ProfileView+BottomBar.swift
+++ b/iOS/Views/Profile/Body/Components/ProfileView+BottomBar.swift
@@ -151,7 +151,6 @@ extension ProfileView.Skeleton.BottomBar {
     struct ActionsListButton: View {
         @State private var inputImage: UIImage?
         @State private var presentImageSheet = false
-        @State private var presentNextEntry = false
         @State private var selections: (DaisukeEngine.Structs.Highlight, String)?
         @EnvironmentObject var model: ProfileView.ViewModel
 
@@ -177,7 +176,6 @@ extension ProfileView.Skeleton.BottomBar {
             .sheet(isPresented: $presentImageSheet) {
                 ImagePicker(image: $inputImage)
             }
-
             .onChange(of: inputImage) { val in
                 guard let val else { return }
                 Task {
@@ -185,22 +183,11 @@ extension ProfileView.Skeleton.BottomBar {
                     await actor.setCustomThumbnail(image: val, id: sttId.id)
                 }
             }
-            .onChange(of: presentNextEntry, perform: { newValue in
-                if !newValue {
-                    selections = nil
-                }
-            })
             .background(
-                VStack {
-                    if let selections = selections {
-                        NavigationLink(destination: ProfileView(entry: selections.0, sourceId: selections.1), isActive: $presentNextEntry) {
-                            EmptyView()
-                        }
-                        .buttonStyle(.plain)
-                        .frame(width: 0)
-                        .opacity(0)
-                    }
+                NavigationLink(value: selections.map { ProfileNavigationDestination(entry: $0.0, sourceId: $0.1) }) {
+                    EmptyView()
                 }
+                .opacity(0)
             )
         }
 

--- a/iOS/Views/ReadLater/ReadLater+CollectionView.swift
+++ b/iOS/Views/ReadLater/ReadLater+CollectionView.swift
@@ -59,7 +59,7 @@ extension LibraryView.ReadLaterView {
             DefaultTile(entry: highlight, sourceId: sourceId)
                 .coloredBadge(inLibrary ? .accentColor : nil)
                 .onTapGesture {
-                    model.selection = (sourceId, nil, highlight)
+                    model.selection = HighlightIdentifier(sourceId: sourceId, sourceName: nil, entry: highlight)
                 }
         }
     }


### PR DESCRIPTION
**Breaking Change:**
Minimum deployment target updated from iOS 15.0 to iOS 16.0

**Problem:**
When switching back from other apps or unlocking the device, detail pages (like ProfileView) automatically dismissed back to library, causing navigation state loss.

**Root Cause:**
NavigationView has known stability issues in iOS 15:
- NavigationLink's @State var isActive gets reset when views recreate
- Navigation stack cleared unexpectedly during memory pressure
- State doesn't survive backgrounding and app lifecycle events
- Inconsistent behavior across different iOS versions

**Solution:**
Migrate to iOS 16+ NavigationStack for stable navigation state management:
- NavigationStack maintains stable NavigationPath across view recreation
- Value-based navigation (NavigationLink(value:)) is more reliable
- .navigationDestination API properly handles state persistence
- Navigation state survives backgrounding and memory pressure

**Changes:**

1. **Navigation Architecture:**
   - SmartNavigationView: NavigationView → NavigationStack with NavigationPath
   - All NavigationLink migrated to value-based navigation pattern
   - InteractableContent: Use ProfileNavigationDestination with NavigationLink(value:)
   - InteractableContainer: Use .navigationDestination(isPresented:) for programmatic navigation
   - LibraryGrid: CollectionModifier and ProfileModifier use .navigationDestination(isPresented:)
   - HiddenNavigationModifier: Updated to use .navigationDestination(isPresented:)
   - MoreView: Wrapped in SmartNavigationView

2. **Type Improvements:**
   - HighlightIdentifier: Tuple → Struct for better type safety and Equatable conformance
   - ProfileNavigationDestination: New Hashable type for NavigationStack value-based navigation

**Benefits:**
- ✅ Navigation state survives app switching and backgrounding
- ✅ Detail pages remain open when returning from background
- ✅ No more unexpected navigation stack clearing
- ✅ Modern iOS 16+ navigation patterns
- ✅ Better memory pressure handling

**Files Changed:**
- Deployment: project.pbxproj (iOS 15.0 → 16.0)
- Navigation Core: TabBar.swift (SmartNavigationView), InteractableContent.swift
- Library: LibraryGrid+ProfileModifier.swift
- Views: MoreView, UpdateFeedView, HistoryView, ReadLaterView, ProfileView+BottomBar
- Highlights: AddContentLink, DSKHighlightTile