### PR TITLE
fix: Add null-safety checks for author and artist metadata

### DIFF
--- a/iOS/Singletons/SauceNao.swift
+++ b/iOS/Singletons/SauceNao.swift
@@ -66,7 +66,7 @@ extension SauceNao {
         var mal_id: Int?
         var source: String
         var part: String
-        var artist: String
-        var author: String
+        var artist: String?
+        var author: String?
     }
 }

--- a/iOS/Views/ImageSearch/ImageSearchView.swift
+++ b/iOS/Views/ImageSearch/ImageSearchView.swift
@@ -102,9 +102,9 @@ extension ImageSearchView {
                     Text(entry.header.similarity + "% Match")
                         .font(.subheadline)
                         .padding(.bottom)
-                    Text("Written By " + entry.data.author)
+                    Text("Written By " + (entry.data.author ?? "Unknown"))
                         .font(.footnote)
-                    Text("Art By " + entry.data.artist)
+                    Text("Art By " + (entry.data.artist ?? "Unknown"))
                         .font(.footnote)
                     Spacer()
                 }


### PR DESCRIPTION
- Make author and artist fields optional (String?) in SauceNao.EntryData
- Use nil-coalescing operator to display 'Unknown' when author/artist is nil
- Prevents TypeError/crashes when SauceNao returns entries with missing metadata
- Gracefully handles incomplete metadata from manga sources and trackers

Fixes: TypeError when manga author field is null/missing Related to Suwayomi sources with incomplete metadata